### PR TITLE
Step9: 필터 및 인터셉터, 예외처리, API 구현 및 테스트

### DIFF
--- a/src/main/java/hhplus/ecommerce/server/config/WebConfig.java
+++ b/src/main/java/hhplus/ecommerce/server/config/WebConfig.java
@@ -1,0 +1,82 @@
+package hhplus.ecommerce.server.config;
+
+import hhplus.ecommerce.server.infrastructure.jwt.JwtUtils;
+import hhplus.ecommerce.server.infrastructure.jwt.MockJwtUtils;
+import hhplus.ecommerce.server.interfaces.filter.AccessLogFilter;
+import hhplus.ecommerce.server.interfaces.filter.XssFilter;
+import hhplus.ecommerce.server.interfaces.interceptor.UserIdInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Bean
+    public JwtUtils jwtUtils() {
+        return new MockJwtUtils();
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new UserIdInterceptor(jwtUtils()))
+                .addPathPatterns("/**")
+                .order(1);
+    }
+
+    @Bean
+    public FilterRegistrationBean<AccessLogFilter> acceeLogFilter() {
+        FilterRegistrationBean<AccessLogFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new AccessLogFilter());
+        registrationBean.setOrder(1);
+        registrationBean.addUrlPatterns("/api/*");
+        return registrationBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean<CorsFilter> corsFilter() {
+        FilterRegistrationBean<CorsFilter> registrationBean = new FilterRegistrationBean<>();
+        CorsFilter corsFilter = configCorsFilter();
+        registrationBean.setFilter(corsFilter);
+        registrationBean.setOrder(2);
+        registrationBean.addUrlPatterns("/*");
+        return registrationBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean<XssFilter> xssFilter() {
+        FilterRegistrationBean<XssFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new XssFilter());
+        registrationBean.setOrder(3);
+        registrationBean.addUrlPatterns("/*");
+        return registrationBean;
+    }
+
+    private CorsFilter configCorsFilter() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        List<String> allowedOrigins = List.of(
+                "https://localhost:3000",
+                "https://localhost:8080"
+        );
+
+        configuration.setAllowCredentials(false);
+        configuration.setAllowedOrigins(allowedOrigins);
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+        configuration.setMaxAge(6000L);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return new CorsFilter(source);
+    }
+}

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/jwt/JwtUtils.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/jwt/JwtUtils.java
@@ -1,0 +1,7 @@
+package hhplus.ecommerce.server.infrastructure.jwt;
+
+public interface JwtUtils {
+
+    boolean hasId(String token);
+    String getId(String token);
+}

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/jwt/MockJwtUtils.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/jwt/MockJwtUtils.java
@@ -1,0 +1,13 @@
+package hhplus.ecommerce.server.infrastructure.jwt;
+
+public class MockJwtUtils implements JwtUtils {
+    @Override
+    public boolean hasId(String token) {
+        return true;
+    }
+
+    @Override
+    public String getId(String token) {
+        return "1";
+    }
+}

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/security/UserIdHolder.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/security/UserIdHolder.java
@@ -1,0 +1,21 @@
+package hhplus.ecommerce.server.infrastructure.security;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class UserIdHolder {
+
+    private final ThreadLocal<String> userId = new ThreadLocal<>();
+
+    public void setUserId(String id) {
+        userId.set(id);
+    }
+
+    public String getUserId() {
+        return userId.get();
+    }
+
+    public void clear() {
+        userId.remove();
+    }
+}

--- a/src/main/java/hhplus/ecommerce/server/interfaces/filter/AccessLogFilter.java
+++ b/src/main/java/hhplus/ecommerce/server/interfaces/filter/AccessLogFilter.java
@@ -1,0 +1,40 @@
+package hhplus.ecommerce.server.interfaces.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+@Slf4j
+public class AccessLogFilter implements Filter {
+
+    // Proxy 서버를 통해 들어온 경우, 클라이언트의 IP 주소를 추출하기 위한 헤더 목록
+    private static final String[] headers = {
+            "X-Forwarded-For",
+            "Proxy-Client-IP",
+            "WL-Proxy-Client-IP",
+            "HTTP_CLIENT_IP",
+            "HTTP_X_FORWARDED_FOR"
+    };
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        log.trace("AccessLogFilter.doFilter");
+        if (request instanceof HttpServletRequest req) {
+            String clientIp = extractClientIp(req);
+            log.trace("{} -> {} {} {}", clientIp, req.getMethod(), req.getRequestURI(), req.getProtocol());
+        }
+        chain.doFilter(request, response);
+    }
+
+    private String extractClientIp(HttpServletRequest request) {
+        for (String header : headers) {
+            String ip = request.getHeader(header);
+            if (ip != null) {
+                return ip;
+            }
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/src/main/java/hhplus/ecommerce/server/interfaces/filter/XssFilter.java
+++ b/src/main/java/hhplus/ecommerce/server/interfaces/filter/XssFilter.java
@@ -1,0 +1,17 @@
+package hhplus.ecommerce.server.interfaces.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+@Slf4j
+public class XssFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        log.trace("XssFilter.doFilter");
+        chain.doFilter(new XssRequestWrapper((HttpServletRequest) request), response);
+    }
+}

--- a/src/main/java/hhplus/ecommerce/server/interfaces/filter/XssRequestWrapper.java
+++ b/src/main/java/hhplus/ecommerce/server/interfaces/filter/XssRequestWrapper.java
@@ -1,0 +1,62 @@
+package hhplus.ecommerce.server.interfaces.filter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+
+// refer to https://pikisvill.tistory.com/43
+// refer to https://im-codding.tistory.com/45
+public class XssRequestWrapper extends HttpServletRequestWrapper {
+    /**
+     * Constructs a request object wrapping the given request.
+     *
+     * @param request The request to wrap
+     * @throws IllegalArgumentException if the request is null
+     */
+    public XssRequestWrapper(HttpServletRequest request) {
+        super(request);
+    }
+
+    @Override
+    public String[] getParameterValues(String parameter) {
+
+        String[] values = super.getParameterValues(parameter);
+        if (values==null)  {
+            return null;
+        }
+        int count = values.length;
+        String[] encodedValues = new String[count];
+        for (int i = 0; i < count; i++) {
+            encodedValues[i] = cleanXSS(values[i]);
+        }
+        return encodedValues;
+    }
+
+    @Override
+    public String getParameter(String parameter) {
+        String value = super.getParameter(parameter);
+        if (value == null) {
+            return null;
+        }
+        return cleanXSS(value);
+    }
+
+    @Override
+    public String getHeader(String name) {
+        String value = super.getHeader(name);
+        if (value == null) {
+            return null;
+        }
+        return cleanXSS(value);
+    }
+
+    private String cleanXSS(String value) {
+        //You'll need to remove the spaces from the html entities below
+        value = value.replaceAll("<", "& lt;").replaceAll(">", "& gt;");
+        value = value.replaceAll("\\(", "& #40;").replaceAll("\\)", "& #41;");
+        value = value.replaceAll("'", "& #39;");
+        value = value.replaceAll("eval\\((.*)\\)", "");
+        value = value.replaceAll("[\\\"\\\'][\\s]*javascript:(.*)[\\\"\\\']", "\"\"");
+        value = value.replaceAll("script", "");
+        return value;
+    }
+}

--- a/src/main/java/hhplus/ecommerce/server/interfaces/interceptor/UserIdInterceptor.java
+++ b/src/main/java/hhplus/ecommerce/server/interfaces/interceptor/UserIdInterceptor.java
@@ -1,0 +1,38 @@
+package hhplus.ecommerce.server.interfaces.interceptor;
+
+import hhplus.ecommerce.server.infrastructure.jwt.JwtUtils;
+import hhplus.ecommerce.server.infrastructure.security.UserIdHolder;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@RequiredArgsConstructor
+@Slf4j
+public class UserIdInterceptor implements HandlerInterceptor {
+
+    private final JwtUtils jwtUtils;
+
+    // JWT 토큰에서 사용자 ID를 추출하여 UserIdHolder 에 저장
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        log.trace("UserIdInterceptor.preHandle");
+        String authorization = request.getHeader("Authorization");
+        if (authorization != null && authorization.startsWith("Bearer ")) {
+            String token = authorization.substring(7);
+            if (jwtUtils.hasId(token)) {
+                String userId = jwtUtils.getId(token);
+                UserIdHolder.setUserId(userId);
+            }
+        }
+        return true;
+    }
+
+    // 요청 처리가 완료된 후 (예외가 발생하더라도 항상) UserIdHolder 에 저장된 사용자 ID를 제거
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        log.trace("UserIdInterceptor.afterCompletion");
+        UserIdHolder.clear();
+    }
+}

--- a/src/test/java/hhplus/ecommerce/server/integration/infrastructure/JwtUtilsTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/infrastructure/JwtUtilsTest.java
@@ -1,0 +1,45 @@
+package hhplus.ecommerce.server.integration.infrastructure;
+
+import hhplus.ecommerce.server.infrastructure.jwt.JwtUtils;
+import hhplus.ecommerce.server.integration.SpringBootTestEnvironment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JwtUtilsTest extends SpringBootTestEnvironment {
+
+    @Autowired
+    JwtUtils jwtUtils;
+
+    @DisplayName("토큰에 아이디가 있는지 검증할 수 있다.")
+    @Test
+    void hasId() {
+        // given
+        String token = createToken();
+
+        // when
+        boolean hasId = jwtUtils.hasId(token);
+
+        // then
+        assertThat(hasId).isTrue();
+    }
+
+    @DisplayName("토큰에서 아이디를 추출할 수 있다.")
+    @Test
+    void getId() {
+        // given
+        String token = createToken();
+
+        // when
+        String id = jwtUtils.getId(token);
+
+        // then
+        assertThat(id).isNotBlank();
+    }
+
+    private static String createToken() {
+        return "Bearer token";
+    }
+}

--- a/src/test/java/hhplus/ecommerce/server/integration/infrastructure/OrderDataPlatformTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/infrastructure/OrderDataPlatformTest.java
@@ -1,0 +1,29 @@
+package hhplus.ecommerce.server.integration.infrastructure;
+
+import hhplus.ecommerce.server.infrastructure.data.OrderDataPlatform;
+import hhplus.ecommerce.server.integration.SpringBootTestEnvironment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+public class OrderDataPlatformTest extends SpringBootTestEnvironment {
+
+    @Autowired
+    OrderDataPlatform orderDataPlatform;
+
+    @DisplayName("주문 데이터 전송 메서드를 예외 없이 실행할 수 있다.")
+    @Test
+    void saveOrderData() {
+        // given
+        Map<Long, Integer> itemIdItemAmountMap = Map.of(1L, 1);
+
+        // when
+        // then
+        assertThatCode(() -> orderDataPlatform.saveOrderData(itemIdItemAmountMap))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/hhplus/ecommerce/server/integration/interfaces/exception/ApiExceptionTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/interfaces/exception/ApiExceptionTest.java
@@ -1,0 +1,49 @@
+package hhplus.ecommerce.server.integration.interfaces.exception;
+
+import hhplus.ecommerce.server.integration.SpringBootTestEnvironment;
+import hhplus.ecommerce.server.interfaces.exception.ApiException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.reflections.Reflections;
+import org.reflections.scanners.Scanners;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+import org.reflections.util.FilterBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ApiExceptionTest extends SpringBootTestEnvironment {
+
+    private final String basePackagePath = "hhplus.ecommerce.server";
+
+    /**
+     * API 예외 코드들을 관리하는 정책으로, 클래스 이름 자체를 사용하고자 합니다.
+     * 이때 클래스 이름이 중복되어선 안 되기 때문에, ApiException 을 상속한 모든 클래스를 찾고 중복을 검사해야 합니다.
+     * 이에 reflections 라는 라이브러리를 사용하여 ApiException 을 상속한 클래스들을 찾고, 중복되는 클래스 이름이 없는지 검사합니다.
+     * 또한 이를 활용하면 추후에 예외코드들을 별도의 문서로 정리할 때도 유용하게 사용할 수 있습니다.
+     */
+    @DisplayName("ApiException 을 상속한 클래스들은 이름이 중복이 없어야 한다.")
+    @Test
+    void check() {
+        // given
+        Reflections reflections = new Reflections(new ConfigurationBuilder()
+                .setScanners(Scanners.SubTypes, Scanners.Resources)
+                .addUrls(ClasspathHelper.forJavaClassPath())
+                .filterInputsBy(new FilterBuilder().includePackage(basePackagePath))
+        );
+        Set<Class<? extends ApiException>> classes = reflections.getSubTypesOf(ApiException.class);
+        Map<String, Object> errorCodes = new HashMap<>();
+
+        // when
+        // then
+        for (Class<? extends ApiException> clazz : classes) {
+            String code = clazz.getSimpleName();
+            assertThat(errorCodes).doesNotContainKey(code);
+            errorCodes.put(code, null);
+        }
+    }
+}

--- a/src/test/java/hhplus/ecommerce/server/integration/interfaces/filter/AccessLogFilterTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/interfaces/filter/AccessLogFilterTest.java
@@ -1,0 +1,32 @@
+package hhplus.ecommerce.server.integration.interfaces.filter;
+
+import hhplus.ecommerce.server.interfaces.filter.AccessLogFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.springframework.http.HttpMethod.GET;
+
+public class AccessLogFilterTest {
+
+    private final AccessLogFilter sut = new AccessLogFilter();
+
+    @DisplayName("요청을 받으면 AccessLogFilter가 실행된다.")
+    @Test
+    void accessLogFilter() throws Exception {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("");
+        request.setMethod(GET.name());
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+
+        // when
+        // then
+        assertThatCode(() -> sut.doFilter(request, response, filterChain))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/hhplus/ecommerce/server/integration/interfaces/filter/CorsFilterTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/interfaces/filter/CorsFilterTest.java
@@ -1,0 +1,67 @@
+package hhplus.ecommerce.server.integration.interfaces.filter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.stream.Stream;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+public class CorsFilterTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    private static Stream<Arguments> provideAllowedOrigins() {
+        return Stream.of(
+                Arguments.of("https://localhost:3000"),
+                Arguments.of("https://localhost:8080")
+        );
+    }
+
+    @MethodSource("provideAllowedOrigins")
+    @ParameterizedTest
+    @DisplayName("허용된 Origin 은 비동기 데이터 요청을 수행할 수 있다.")
+    void allowedOrigins(String origin) throws Exception {
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("")
+                        .header("Access-Control-Request-Method", "GET")
+                        .header("Origin", origin)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions.andExpect(status().isNotFound());
+    }
+
+    @DisplayName("허용되지 않은 Origin 은 비동기 데이터 요청을 수행할 수 없다.")
+    @Test
+    void notAllowedOrigins() throws Exception {
+        // given
+        String origin = "https://localhost:4000";
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("")
+                        .header("Access-Control-Request-Method", "GET")
+                        .header("Origin", origin)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions.andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/hhplus/ecommerce/server/integration/interfaces/filter/XssFilterTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/interfaces/filter/XssFilterTest.java
@@ -1,0 +1,45 @@
+package hhplus.ecommerce.server.integration.interfaces.filter;
+
+import hhplus.ecommerce.server.interfaces.filter.XssFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class XssFilterTest {
+
+    private final XssFilter sut = new XssFilter();
+
+    @DisplayName("Cross-site Scripting 공격이 오면 이를 방어할 수 있다.")
+    @Test
+    void xssFilter() throws Exception {
+        // given
+        String header = "<script>alert('xss')</script>"; // & lt;& gt;alert& #40;& #39;xss& #39;& #41;& lt;/& gt;
+        String param = "<script>alert('xss')</script>"; // & lt;& gt;alert& #40;& #39;xss& #39;& #41;& lt;/& gt;
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("");
+        request.setMethod("GET");
+        request.addHeader("Header", header);
+        request.addParameter("param", param);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+
+        // when
+        sut.doFilter(request, response, filterChain);
+
+        // then
+        HttpServletRequest filteredRequest = (HttpServletRequest) filterChain.getRequest();
+        assertThat(filteredRequest).isNotNull();
+        String filteredHeader = filteredRequest.getHeader("Header");
+        String filteredParam = filteredRequest.getParameter("param");
+        String[] filteredParamterValues = filteredRequest.getParameterValues("param");
+        assertThat(filteredHeader).isEqualTo("& lt;& gt;alert& #40;& #39;xss& #39;& #41;& lt;/& gt;");
+        assertThat(filteredParam).isEqualTo("& lt;& gt;alert& #40;& #39;xss& #39;& #41;& lt;/& gt;");
+        assertThat(filteredParamterValues).containsExactly("& lt;& gt;alert& #40;& #39;xss& #39;& #41;& lt;/& gt;");
+    }
+}

--- a/src/test/java/hhplus/ecommerce/server/integration/interfaces/filter/XssRequestWrapperTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/interfaces/filter/XssRequestWrapperTest.java
@@ -1,0 +1,76 @@
+package hhplus.ecommerce.server.integration.interfaces.filter;
+
+import hhplus.ecommerce.server.interfaces.filter.XssRequestWrapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class XssRequestWrapperTest {
+
+    private MockHttpServletRequest request;
+    private XssRequestWrapper sut;
+
+    @BeforeEach
+    void setUp() {
+        request = new MockHttpServletRequest();
+        sut = new XssRequestWrapper(request);
+    }
+
+    @DisplayName("Header 의 Cross-site Scripting 공격이 오면 이를 방어할 수 있다.")
+    @Test
+    void clearXssOnHeader() {
+        // given
+        String target = "<script>alert('xss')</script>"; // & lt;& gt;alert& #40;& #39;xss& #39;& #41;& lt;/& gt;
+        request.setRequestURI("");
+        request.setMethod("GET");
+        request.addHeader("Header", target);
+
+        // when
+        String authorization = sut.getHeader("Header");
+
+        // then
+        assertThat(authorization).isEqualTo("& lt;& gt;alert& #40;& #39;xss& #39;& #41;& lt;/& gt;");
+    }
+
+    @DisplayName("Parameter 의 Cross-site Scripting 공격이 오면 이를 방어할 수 있다.")
+    @Test
+    void clearXssOnParameter() {
+        // given
+        String target = "<script>alert('xss')</script>"; // & lt;& gt;alert& #40;& #39;xss& #39;& #41;& lt;/& gt;
+
+        request.setRequestURI("");
+        request.setMethod("GET");
+        request.addParameter("param", target);
+
+        // when
+        String parameter = sut.getParameter("param");
+
+        // then
+        assertThat(parameter).isEqualTo("& lt;& gt;alert& #40;& #39;xss& #39;& #41;& lt;/& gt;");
+    }
+
+    @DisplayName("여러 파라미터의 Cross-site Scripting 공격이 오면 이를 방어할 수 있다.")
+    @Test
+    void cleanXssOnParameterValues() {
+        // given
+        String target1 = "<script>alert('hello')</script>"; // & lt;& gt;alert& #40;& #39;hello& #39;& #41;& lt;/& gt;
+        String target2 = "<script>alert('world')</script>"; // & lt;& gt;alert& #40;& #39;world& #39;& #41;& lt;/& gt;
+
+        request.setRequestURI("");
+        request.setMethod("GET");
+        request.addParameter("param", target1);
+        request.addParameter("param", target2);
+
+        // when
+        String[] parameterValues = sut.getParameterValues("param");
+
+        // then
+        assertThat(parameterValues).containsExactly(
+                "& lt;& gt;alert& #40;& #39;hello& #39;& #41;& lt;/& gt;",
+                "& lt;& gt;alert& #40;& #39;world& #39;& #41;& lt;/& gt;"
+        );
+    }
+}

--- a/src/test/java/hhplus/ecommerce/server/integration/interfaces/interceptor/UserIdInterceptorTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/interfaces/interceptor/UserIdInterceptorTest.java
@@ -1,0 +1,55 @@
+package hhplus.ecommerce.server.integration.interfaces.interceptor;
+
+import hhplus.ecommerce.server.infrastructure.jwt.JwtUtils;
+import hhplus.ecommerce.server.infrastructure.security.UserIdHolder;
+import hhplus.ecommerce.server.integration.SpringBootTestEnvironment;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.mockStatic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+public class UserIdInterceptorTest extends SpringBootTestEnvironment {
+
+    private static MockedStatic<UserIdHolder> mockedStatic;
+
+    @MockBean
+    JwtUtils jwtUtils;
+
+    @BeforeAll
+    static void beforeAll() {
+        mockedStatic = mockStatic(UserIdHolder.class);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        mockedStatic.close();
+    }
+
+    @DisplayName("토큰이 전달되면 이를 ThreadLocal 에서 비즈니스 로직이 끝날 때까지 보관할 수 있다.")
+    @Test
+    void userIdInterceptor() throws Exception {
+        // mock
+        when(jwtUtils.hasId(anyString())).thenReturn(true);
+        when(jwtUtils.getId(anyString())).thenReturn("userId");
+
+        // given
+        String authorization = "Bearer token";
+
+        // when
+        mockMvc.perform(get("").header(HttpHeaders.AUTHORIZATION, authorization));
+
+        // then
+        verify(jwtUtils, times(1)).hasId(anyString());
+        verify(jwtUtils, times(1)).getId(anyString());
+        mockedStatic.verify(() -> UserIdHolder.setUserId("userId"), times(1));
+        mockedStatic.verify(UserIdHolder::clear, times(1));
+    }
+}

--- a/src/test/java/hhplus/ecommerce/server/unit/infrastructure/UserIdHolderTest.java
+++ b/src/test/java/hhplus/ecommerce/server/unit/infrastructure/UserIdHolderTest.java
@@ -1,0 +1,38 @@
+package hhplus.ecommerce.server.unit.infrastructure;
+
+import hhplus.ecommerce.server.infrastructure.security.UserIdHolder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserIdHolderTest {
+
+    @DisplayName("UserIdHolder 는 사용자의 id 를 보관하고 반환할 수 있다.")
+    @Test
+    void setAndGet() {
+        // given
+        String id = "id";
+
+        // when
+        UserIdHolder.setUserId(id);
+        String userId = UserIdHolder.getUserId();
+
+        // then
+        assertThat(userId).isEqualTo(id);
+    }
+
+    @DisplayName("UserIdHolder 에서 사용자의 id 를 제거할 수 있다.")
+    @Test
+    void setAndClear() {
+        // given
+        String id = "id";
+        UserIdHolder.setUserId(id);
+
+        // when
+        UserIdHolder.clear();
+
+        // then
+        assertThat(UserIdHolder.getUserId()).isNull();
+    }
+}


### PR DESCRIPTION
### 변경사항
- **필터와 인터셉터를 구현**했습니다.
- 평소에 필터와 인터셉터 테스트는 잘 안 하다보니... 기능구현한 이후에 테스트 생각이 나서 한 번 시도해봤습니다.
  - 필터 테스트를 위해 **Spring 에서 제공하는 Mock 객체**가 있길래 이를 활용한 **통합테스트**(Spring 에 의존한 테스트이므로 통합테스트로 분류)를 진행했습니다.

### 참고사항
- 지난 주차에 추가해둔 **ControllerAdvice 와 API 구현 및 그 테스트들**이 있어서 PR 대신 링크를 남깁니다.
  - API 테스트는 Controller 테스트와 Dto 검증 테스트 2개로 나뉩니다.
- 소스코드 내려받으실 분은 [STEP10+ 브랜치](https://github.com/psam1017/hhplus-ecommerce/tree/STEP10%2B)에서 내려받으시기 바랍니다.
  - STEP 10까지의 내용에서 추가로, **주문 API 를 바로 주문 API 와 장바구니 주문 API 로 분리**한 현재 PR 생성 시점 최신 브랜치입니다.

### 코치님 및 리뷰어에게 리뷰 요청!
- [RestControllerAdvice](https://github.com/psam1017/hhplus-ecommerce/blob/STEP10/src/main/java/hhplus/ecommerce/server/interfaces/exception/WebControllerAdvice.java) 에서 **값 유효성 검증하는 부분의 로그 레벨은 error 가 적절**할까요?
  - 비즈니스 로직 상 발생한 예외 `ApiException`은 info 레벨로 기록합니다.
  - 그 외 발견하지 못 한 모든 예외 `Exception`에 대해서는 error 레벨로 기록합니다.
  - @Valid 를 사용한 값 유효성 검사하는 부분에서 발생한 예외는 error 레벨이 적절할까요? 이러한 값 검증은 프론트엔드에서 한 번 검증한 이후에 보내줄 수 있고, 그렇게 했을 때 불필요한 네트워킹이 발생하지 않기 때문에 프론트엔드의 유효성 검사가 필요하다고 생각합니다. 그래서 이 예외들은 백엔드에서 발생하지 않는 게 가장 이상적인 예외라고 생각하고, 발생했을 때는 경각심을 가지자는 의미에서 error 로 잡았는데 너무 과한 레벨일까요?

### 바로가기
- [예외처리 관련 패키지](https://github.com/psam1017/hhplus-ecommerce/tree/STEP10/src/main/java/hhplus/ecommerce/server/interfaces/exception)
- [RestControllerAdvice.java](https://github.com/psam1017/hhplus-ecommerce/blob/STEP10/src/main/java/hhplus/ecommerce/server/interfaces/exception/WebControllerAdvice.java)
- [API 구현 패키지](https://github.com/psam1017/hhplus-ecommerce/tree/STEP10/src/main/java/hhplus/ecommerce/server/interfaces/controller)
- [API 테스트 패키지](https://github.com/psam1017/hhplus-ecommerce/tree/STEP10/src/test/java/hhplus/ecommerce/server/integration/interfaces/controller)
