### PR TITLE
Step10+: 주문 API 를 분리하여 생성

### DIFF
--- a/src/main/java/hhplus/ecommerce/server/application/CartFacade.java
+++ b/src/main/java/hhplus/ecommerce/server/application/CartFacade.java
@@ -1,5 +1,6 @@
 package hhplus.ecommerce.server.application;
 
+import hhplus.ecommerce.server.domain.cart.Cart;
 import hhplus.ecommerce.server.domain.cart.service.CartCommand;
 import hhplus.ecommerce.server.domain.cart.service.CartInfo;
 import hhplus.ecommerce.server.domain.cart.service.CartService;
@@ -12,6 +13,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Component
@@ -27,13 +31,16 @@ public class CartFacade {
 
         User user = userService.getUser(command.userId());
         Item item = itemService.getItem(command.itemId());
-        return CartInfo.CartDetail.from(cartService.putItem(command.toCart(user, item)));
+        return CartInfo.CartDetail.from(cartService.putItem(command.toCart(user, item)), itemStock.getAmount());
     }
 
     public List<CartInfo.CartDetail> getCartItems(Long userId) {
-        return cartService.getCartItems(userId).stream()
-                .map(CartInfo.CartDetail::from)
-                .toList();
+        List<Cart> cartItems = cartService.getCartItems(userId);
+        Set<Long> itemIds = cartItems.stream().map(c -> c.getItem().getId()).collect(Collectors.toSet());
+        Map<Long, Integer> itemIdStockAmountMap = itemService.getStocks(itemIds);
+        return cartItems.stream()
+                .map(c -> CartInfo.CartDetail.from(c, itemIdStockAmountMap.get(c.getItem().getId())))
+                .collect(Collectors.toList());
     }
 
     public Long deleteCartItem(Long userId, Long itemId) {

--- a/src/main/java/hhplus/ecommerce/server/domain/cart/service/CartInfo.java
+++ b/src/main/java/hhplus/ecommerce/server/domain/cart/service/CartInfo.java
@@ -11,15 +11,17 @@ public class CartInfo {
             Long itemId,
             String name,
             Integer price,
-            Integer amount
+            Integer amount,
+            Integer leftStock
     ) {
-        public static CartDetail from(Cart cart) {
+        public static CartDetail from(Cart cart, int leftStock) {
             return new CartDetail(
                     cart.getId(),
                     cart.getItem().getId(),
                     cart.getItem().getName(),
                     cart.getItem().getPrice(),
-                    cart.getQuantity()
+                    cart.getQuantity(),
+                    leftStock
             );
         }
     }

--- a/src/main/java/hhplus/ecommerce/server/domain/cart/service/CartRepository.java
+++ b/src/main/java/hhplus/ecommerce/server/domain/cart/service/CartRepository.java
@@ -17,4 +17,8 @@ public interface CartRepository {
     void delete(Cart cart);
 
     void deleteByUserIdAndItemIds(Long userId, Set<Long> itemIds);
+
+    void deleteAllById(Set<Long> cartIds);
+
+    List<Cart> findAllByUserIdAndIdIn(Long userId, Set<Long> itemIds);
 }

--- a/src/main/java/hhplus/ecommerce/server/domain/cart/service/CartService.java
+++ b/src/main/java/hhplus/ecommerce/server/domain/cart/service/CartService.java
@@ -31,13 +31,21 @@ public class CartService {
         return cartRepository.findAllByUserId(userId);
     }
 
+    public List<Cart> getCartItems(Long userId, Set<Long> cartIds) {
+        List<Cart> cartItems = cartRepository.findAllByUserIdAndIdIn(userId, cartIds);
+        if (cartItems.size() != cartIds.size()) {
+            throw new NoSuchCartException();
+        }
+        return cartItems;
+    }
+
     public Long deleteCartItem(Long userId, Long itemId) {
         Cart cart = cartRepository.findByUserIdAndItemId(userId, itemId).orElseThrow(NoSuchCartException::new);
         cartRepository.delete(cart);
         return cart.getId();
     }
 
-    public void deleteCartItems(Long userId, Set<Long> itemIds) {
-        cartRepository.deleteByUserIdAndItemIds(userId, itemIds);
+    public void deleteCartItems(Set<Long> cartIds) {
+        cartRepository.deleteAllById(cartIds);
     }
 }

--- a/src/main/java/hhplus/ecommerce/server/domain/order/service/OrderCommand.java
+++ b/src/main/java/hhplus/ecommerce/server/domain/order/service/OrderCommand.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 
 public class OrderCommand {
 
-    public record CreateOrder(
+    public record CreateOrderByItem(
             Long userId,
             List<CreateOrderItem> items
     ) {
@@ -60,6 +60,32 @@ public class OrderCommand {
                     .map(CreateOrderItem::amount)
                     .findAny()
                     .orElseThrow(NoSuchItemStockException::new);
+        }
+    }
+
+    public record CreateOrderByCart(
+            Long userId,
+            Set<Long> cartIds
+    ) {
+
+        public Order toOrder(User user) {
+            return Order.builder()
+                    .user(user)
+                    .status(OrderStatus.ORDERED)
+                    .orderDateTime(LocalDateTime.now())
+                    .build();
+        }
+
+        public List<OrderItem> toOrderItems(List<Item> items, Map<Long, Integer> itemIdStockAmountMap, Order order) {
+            return items.stream()
+                    .map(item -> OrderItem.builder()
+                            .order(order)
+                            .item(item)
+                            .name(item.getName())
+                            .price(item.getPrice())
+                            .quantity(itemIdStockAmountMap.get(item.getId()))
+                            .build())
+                    .collect(Collectors.toList());
         }
     }
 

--- a/src/main/java/hhplus/ecommerce/server/domain/order/service/OrderService.java
+++ b/src/main/java/hhplus/ecommerce/server/domain/order/service/OrderService.java
@@ -36,9 +36,15 @@ public class OrderService {
         return orderItemRepository.findOrderAmounts(orderIds);
     }
 
-    public Order createOrderAndItems(OrderCommand.CreateOrder command, User user, List<Item> items) {
+    public Order createOrderAndItems(OrderCommand.CreateOrderByItem command, User user, List<Item> items) {
         Order order = orderRepository.save(command.toOrder(user));
         orderItemRepository.saveAll(command.toOrderItems(items, order));
+        return order;
+    }
+
+    public Order createOrderAndItems(OrderCommand.CreateOrderByCart command, User user, List<Item> items, Map<Long, Integer> itemStockAmountMap) {
+        Order order = orderRepository.save(command.toOrder(user));
+        orderItemRepository.saveAll(command.toOrderItems(items, itemStockAmountMap, order));
         return order;
     }
 }

--- a/src/main/java/hhplus/ecommerce/server/domain/point/service/PointService.java
+++ b/src/main/java/hhplus/ecommerce/server/domain/point/service/PointService.java
@@ -37,6 +37,9 @@ public class PointService {
         int totalPrice = 0;
         for (Item item : items) {
             totalPrice += item.getPrice() * itemIdStockAmountMap.get(item.getId());
+            System.out.println("item.getPrice() = " + item.getPrice());
+            System.out.println("itemIdStockAmountMap.get(item.getId()) = " + itemIdStockAmountMap.get(item.getId()));
+            System.out.println("totalPrice = " + totalPrice);
         }
         return totalPrice;
     }

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/cart/CartJpaRepository.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/cart/CartJpaRepository.java
@@ -13,4 +13,6 @@ public interface CartJpaRepository extends JpaRepository<Cart, Long> {
     List<Cart> findAllByUserId(Long userId);
 
     void deleteByUserIdAndItemIdIn(Long userId, Set<Long> itemIds);
+
+    List<Cart> findAllByUserIdAndIdIn(Long userId, Set<Long> ids);
 }

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/cart/CartRepositoryImpl.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/cart/CartRepositoryImpl.java
@@ -41,4 +41,14 @@ public class CartRepositoryImpl implements CartRepository {
     public void deleteByUserIdAndItemIds(Long userId, Set<Long> itemIds) {
         cartJpaRepository.deleteByUserIdAndItemIdIn(userId, itemIds);
     }
+
+    @Override
+    public void deleteAllById(Set<Long> cartIds) {
+        cartJpaRepository.deleteAllById(cartIds);
+    }
+
+    @Override
+    public List<Cart> findAllByUserIdAndIdIn(Long userId, Set<Long> cartIds) {
+        return cartJpaRepository.findAllByUserIdAndIdIn(userId, cartIds);
+    }
 }

--- a/src/main/java/hhplus/ecommerce/server/interfaces/controller/cart/CartDto.java
+++ b/src/main/java/hhplus/ecommerce/server/interfaces/controller/cart/CartDto.java
@@ -24,7 +24,9 @@ public class CartDto {
             Integer price,
 
             @Schema(name = "amount", description = "상품의 수량", example = "1")
-            Integer amount
+            Integer amount,
+            @Schema(name = "leftStock", description = "상품의 재고", example = "10")
+            Integer leftStock
     ) {
         public static CartItemResponse from(CartInfo.CartDetail cartDetail) {
             return new CartItemResponse(
@@ -32,7 +34,8 @@ public class CartDto {
                     cartDetail.itemId(),
                     cartDetail.name(),
                     cartDetail.price(),
-                    cartDetail.amount()
+                    cartDetail.amount(),
+                    cartDetail.leftStock()
             );
         }
     }

--- a/src/main/java/hhplus/ecommerce/server/interfaces/controller/order/OrderController.java
+++ b/src/main/java/hhplus/ecommerce/server/interfaces/controller/order/OrderController.java
@@ -34,7 +34,7 @@ public class OrderController {
                     description = "주문 생성 정보",
                     required = true,
                     content = @Content(
-                            schema = @Schema(implementation = OrderDto.OrderCreate.class)
+                            schema = @Schema(implementation = OrderDto.OrderCreateFromItem.class)
                     )
             ),
             responses = {
@@ -50,14 +50,50 @@ public class OrderController {
     @PostMapping("")
     public OrderDto.OrderIdResponse createOrder(
             @PathVariable Long userId,
-            @RequestBody @Valid OrderDto.OrderCreate post
+            @RequestBody @Valid OrderDto.OrderCreateFromItem post
     ) {
         return new OrderDto.OrderIdResponse(orderFacade.createOrder(
-                new OrderCommand.CreateOrder(
+                new OrderCommand.CreateOrderByItem(
                         userId,
                         post.items().stream()
                                 .map(item -> new OrderCommand.CreateOrderItem(item.itemId(), item.amount()))
                                 .toList()
+                )
+        ));
+    }
+
+    @Operation(
+            summary = "장바구니에서 주문 생성",
+            description = "특정 사용자의 장바구니에서 주문을 생성합니다.",
+            parameters = {
+                    @Parameter(name = "userId", description = "사용자의 고유 식별자", required = true, in = ParameterIn.PATH)
+            },
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "주문 생성 정보",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = OrderDto.OrderCreateFromCart.class)
+                    )
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "생성된 주문의 ID",
+                            content = @Content(
+                                    schema = @Schema(implementation = OrderDto.OrderIdResponse.class)
+                            )
+                    )
+            }
+    )
+    @PostMapping("/carts")
+    public OrderDto.OrderIdResponse createOrderFromCart(
+            @PathVariable Long userId,
+            @RequestBody @Valid OrderDto.OrderCreateFromCart post
+    ) {
+        return new OrderDto.OrderIdResponse(orderFacade.createOrder(
+                new OrderCommand.CreateOrderByCart(
+                        userId,
+                        post.cartIds()
                 )
         ));
     }

--- a/src/main/java/hhplus/ecommerce/server/interfaces/controller/order/OrderDto.java
+++ b/src/main/java/hhplus/ecommerce/server/interfaces/controller/order/OrderDto.java
@@ -10,10 +10,11 @@ import jakarta.validation.constraints.Positive;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 public class OrderDto {
 
-    public record OrderCreate(
+    public record OrderCreateFromItem(
             @NotEmpty @Valid
             @Schema(name = "items", description = "주문 항목 목록", example = "[{\"itemId\":101, \"amount\":2}]")
             List<OrderCreateItem> items
@@ -28,6 +29,13 @@ public class OrderDto {
             @NotNull
             @Schema(name = "amount", description = "주문할 상품의 수량", example = "2")
             Integer amount
+    ) {
+    }
+
+    public record OrderCreateFromCart(
+            @NotEmpty
+            @Schema(name = "cartIds", description = "장바구니 ID 목록", example = "[101, 102]")
+            Set<Long> cartIds
     ) {
     }
 

--- a/src/test/java/hhplus/ecommerce/server/integration/application/OrderFacadeConcurrencyTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/application/OrderFacadeConcurrencyTest.java
@@ -1,12 +1,14 @@
 package hhplus.ecommerce.server.integration.application;
 
 import hhplus.ecommerce.server.application.OrderFacade;
+import hhplus.ecommerce.server.domain.cart.Cart;
 import hhplus.ecommerce.server.domain.item.Item;
 import hhplus.ecommerce.server.domain.item.ItemStock;
 import hhplus.ecommerce.server.domain.item.exception.OutOfItemStockException;
 import hhplus.ecommerce.server.domain.order.service.OrderCommand;
 import hhplus.ecommerce.server.domain.point.Point;
 import hhplus.ecommerce.server.domain.user.User;
+import hhplus.ecommerce.server.infrastructure.cart.CartJpaRepository;
 import hhplus.ecommerce.server.infrastructure.data.OrderDataPlatform;
 import hhplus.ecommerce.server.infrastructure.item.ItemJpaRepository;
 import hhplus.ecommerce.server.infrastructure.item.ItemStockJpaRepository;
@@ -23,6 +25,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -55,11 +58,15 @@ public class OrderFacadeConcurrencyTest {
     @Autowired
     OrderItemJpaRepository orderItemJpaRepository;
 
+    @Autowired
+    CartJpaRepository cartJpaRepository;
+
     @MockBean
     OrderDataPlatform orderDataPlatform;
 
     @AfterEach
     void tearDown() {
+        cartJpaRepository.deleteAll();
         orderItemJpaRepository.deleteAll();
         orderJpaRepository.deleteAll();
         itemStockJpaRepository.deleteAll();
@@ -68,9 +75,9 @@ public class OrderFacadeConcurrencyTest {
         userJpaRepository.deleteAll();
     }
 
-    @DisplayName("동시에 발생한 30번의 주문 요청을 충돌 없이 처리할 수 있다.")
+    @DisplayName("상품 아이디로 동시에 발생한 30번의 주문 요청을 충돌 없이 처리할 수 있다.")
     @Test
-    void createOrder() throws InterruptedException {
+    void createOrderByItem() throws InterruptedException {
         // given
         int stockAmount = 10;
 
@@ -96,9 +103,68 @@ public class OrderFacadeConcurrencyTest {
             executorService.execute(() -> {
                 try {
                     startLatch.await();
-                    OrderCommand.CreateOrder command = new OrderCommand.CreateOrder(
+                    OrderCommand.CreateOrderByItem command = new OrderCommand.CreateOrderByItem(
                             user.getId(),
                             List.of(new OrderCommand.CreateOrderItem(item.getId(), 1))
+                    );
+                    orderFacade.createOrder(command);
+                    successCount.incrementAndGet();
+                } catch (OutOfItemStockException e) {
+                    failCount.incrementAndGet();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+
+        // when
+        startLatch.countDown();
+        endLatch.await();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(stockAmount);
+        assertThat(failCount.get()).isEqualTo(30 - stockAmount);
+
+        ItemStock itemStock = itemStockJpaRepository.findByItemId(item.getId()).orElseThrow();
+        assertThat(itemStock.getAmount()).isEqualTo(0);
+
+        verify(orderDataPlatform, times(stockAmount)).saveOrderData(anyMap());
+    }
+
+    @DisplayName("장바구니 아이디로 동시에 발생한 30번의 주문 요청을 충돌 없이 처리할 수 있다.")
+    @Test
+    void createOrderByCart() throws InterruptedException {
+        // given
+        int stockAmount = 10;
+
+        Item item = createItem("item1", 1000);
+        createItemStock(stockAmount, item);
+
+        List<User> users = new ArrayList<>();
+        for (int i = 0; i < 30; i++) {
+            User user = createUser("testUser");
+            createPoint(1000, user);
+            users.add(user);
+        }
+
+        ExecutorService executorService = Executors.newFixedThreadPool(30);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(30);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        for (int i = 0; i < 30; i++) {
+            User user = users.get(i);
+            executorService.execute(() -> {
+                try {
+                    startLatch.await();
+                    Cart cart = createCart(user, item, 1);
+                    OrderCommand.CreateOrderByCart command = new OrderCommand.CreateOrderByCart(
+                            user.getId(),
+                            Set.of(cart.getId())
                     );
                     orderFacade.createOrder(command);
                     successCount.incrementAndGet();
@@ -150,6 +216,14 @@ public class OrderFacadeConcurrencyTest {
         return itemStockJpaRepository.save(ItemStock.builder()
                 .amount(amount)
                 .item(item)
+                .build());
+    }
+
+    private Cart createCart(User user, Item item, int quantity) {
+        return cartJpaRepository.save(Cart.builder()
+                .user(user)
+                .item(item)
+                .quantity(quantity)
                 .build());
     }
 }

--- a/src/test/java/hhplus/ecommerce/server/integration/interfaces/controller/cart/CartControllerTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/interfaces/controller/cart/CartControllerTest.java
@@ -48,7 +48,7 @@ public class CartControllerTest {
     @DisplayName("장바구니에 상품을 담으면 이를 저장할 수 있다.")
     void putItemIntoCartTest() throws Exception {
         // given
-        CartInfo.CartDetail cartDetail = new CartInfo.CartDetail(1L, 101L, "사과", 1000, 2);
+        CartInfo.CartDetail cartDetail = new CartInfo.CartDetail(1L, 101L, "사과", 1000, 2, 10);
         when(cartFacade.putItem(any(CartCommand.PutItem.class)))
                 .thenReturn(cartDetail);
 
@@ -68,7 +68,8 @@ public class CartControllerTest {
                 .andExpect(jsonPath("$.itemId").value(101L))
                 .andExpect(jsonPath("$.name").value("사과"))
                 .andExpect(jsonPath("$.price").value(1000))
-                .andExpect(jsonPath("$.amount").value(2));
+                .andExpect(jsonPath("$.amount").value(2))
+                .andExpect(jsonPath("$.leftStock").value(10));
     }
 
     @Test
@@ -77,8 +78,8 @@ public class CartControllerTest {
         // given
         Long userId = 1L;
         List<CartInfo.CartDetail> cartItemResponseList = List.of(
-                new CartInfo.CartDetail(1L, 101L, "사과", 1000, 3),
-                new CartInfo.CartDetail(2L, 102L, "바나나", 2000, 1)
+                new CartInfo.CartDetail(1L, 101L, "사과", 1000, 3, 10),
+                new CartInfo.CartDetail(2L, 102L, "바나나", 2000, 1, 20)
         );
 
         when(cartFacade.getCartItems(userId))
@@ -98,12 +99,13 @@ public class CartControllerTest {
                 .andExpect(jsonPath("$.items[0].name").value("사과"))
                 .andExpect(jsonPath("$.items[0].price").value(1000))
                 .andExpect(jsonPath("$.items[0].amount").value(3))
+                .andExpect(jsonPath("$.items[0].leftStock").value(10))
                 .andExpect(jsonPath("$.items[1].id").value(2L))
                 .andExpect(jsonPath("$.items[1].itemId").value(102L))
                 .andExpect(jsonPath("$.items[1].name").value("바나나"))
                 .andExpect(jsonPath("$.items[1].price").value(2000))
                 .andExpect(jsonPath("$.items[1].amount").value(1))
-                .andDo(MockMvcResultHandlers.print());
+                .andExpect(jsonPath("$.items[1].leftStock").value(20));
     }
 
     @Test

--- a/src/test/java/hhplus/ecommerce/server/integration/interfaces/controller/order/OrderDtoTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/interfaces/controller/order/OrderDtoTest.java
@@ -25,12 +25,12 @@ public class OrderDtoTest extends SpringBootTestEnvironment {
 
     @DisplayName("주문할 때 주문할 정보 배열을 보내지 않으면 유효성 검증에 실패한다.")
     @Test
-    void OrderCreateNotNull() {
+    void OrderCreateFromItemNotNull() {
         // given
-        OrderDto.OrderCreate target = new OrderDto.OrderCreate(null);
+        OrderDto.OrderCreateFromItem target = new OrderDto.OrderCreateFromItem(null);
 
         // when
-        Set<ConstraintViolation<OrderDto.OrderCreate>> validations = validator.validate(target);
+        Set<ConstraintViolation<OrderDto.OrderCreateFromItem>> validations = validator.validate(target);
 
         // then
         assertThat(validations).hasSize(1)
@@ -40,12 +40,12 @@ public class OrderDtoTest extends SpringBootTestEnvironment {
 
     @DisplayName("주문할 때 주문할 정보 배열이 비어있으면 유효성 검증에 실패한다.")
     @Test
-    void OrderCreateNotEmpty() {
+    void OrderCreateFromItemNotEmpty() {
         // given
-        OrderDto.OrderCreate target = new OrderDto.OrderCreate(List.of());
+        OrderDto.OrderCreateFromItem target = new OrderDto.OrderCreateFromItem(List.of());
 
         // when
-        Set<ConstraintViolation<OrderDto.OrderCreate>> validations = validator.validate(target);
+        Set<ConstraintViolation<OrderDto.OrderCreateFromItem>> validations = validator.validate(target);
 
         // then
         assertThat(validations).hasSize(1)
@@ -85,14 +85,14 @@ public class OrderDtoTest extends SpringBootTestEnvironment {
 
     @DisplayName("주문 생성 정보를 검증할 때는 주문 정보 배열의 값도 검증할 수 있다.")
     @Test
-    void OrderCreateValid() {
+    void OrderCreateFromItemValid() {
         // given
-        OrderDto.OrderCreate target = new OrderDto.OrderCreate(List.of(
+        OrderDto.OrderCreateFromItem target = new OrderDto.OrderCreateFromItem(List.of(
                 new OrderDto.OrderCreateItem(null, null)
         ));
 
         // when
-        Set<ConstraintViolation<OrderDto.OrderCreate>> validations = validator.validate(target);
+        Set<ConstraintViolation<OrderDto.OrderCreateFromItem>> validations = validator.validate(target);
 
         // then
         assertThat(validations).hasSize(2)
@@ -101,5 +101,35 @@ public class OrderDtoTest extends SpringBootTestEnvironment {
                         tuple("items[0].itemId", NotNull.class),
                         tuple("items[0].amount", NotNull.class)
                 );
+    }
+
+    @DisplayName("장바구니로 주문 생성 정보를 검증할 때는 장바구니 ID 목록을 보내지 않으면 유효성 검증에 실패한다.")
+    @Test
+    void OrderCreateFromCartNotNull() {
+        // given
+        OrderDto.OrderCreateFromCart target = new OrderDto.OrderCreateFromCart(null);
+
+        // when
+        Set<ConstraintViolation<OrderDto.OrderCreateFromCart>> validations = validator.validate(target);
+
+        // then
+        assertThat(validations).hasSize(1)
+                .extracting(cv -> tuple(cv.getPropertyPath().toString(), cv.getConstraintDescriptor().getAnnotation().annotationType()))
+                .contains(tuple("cartIds", NotEmpty.class));
+    }
+
+    @DisplayName("장바구니로 주문 생성 정보를 검증할 때는 장바구니 ID 목록이 비어있으면 유효성 검증에 실패한다.")
+    @Test
+    void OrderCreateFromCartNotEmpty() {
+        // given
+        OrderDto.OrderCreateFromCart target = new OrderDto.OrderCreateFromCart(Set.of());
+
+        // when
+        Set<ConstraintViolation<OrderDto.OrderCreateFromCart>> validations = validator.validate(target);
+
+        // then
+        assertThat(validations).hasSize(1)
+                .extracting(cv -> tuple(cv.getPropertyPath().toString(), cv.getConstraintDescriptor().getAnnotation().annotationType()))
+                .contains(tuple("cartIds", NotEmpty.class));
     }
 }


### PR DESCRIPTION
### 변경사항
- 장바구니 조회 시 프론트에서 직접 검증할 수 있도록 조회하는 **상품의 남은 재고수량을 응답**해줍니다.
- 기존의 주문 로직이 바로 주문 및 장바구니 주문을 한꺼번에 처리하려고 했었는데, 사용자에게 오해의 여지를 줄 수 있을 것 같아서 API 를 2개로 분리하였습니다.
  - 오해의 여지란, 바로 주문하기를 사용했는데도 장바구니에 담아뒀던 특정 상품들이 사라지는 경우를 뜻합니다. 기존 로직이 그렇게 되어 있었습니다.
  - 기존의 API 및 로직에서는 장바구니 로직을 완전히 덜어냈고, **새로운 API 및 로직에서는 오직 장바구니 정보만 받아 주문을 처리**하는 식으로 변경했습니다.