### PR TITLE
Step13- : 캐시 적용 전 목록 조회 로직을 페이지네이션으로 변경

### DIFF
--- a/src/main/java/hhplus/ecommerce/server/application/ItemFacade.java
+++ b/src/main/java/hhplus/ecommerce/server/application/ItemFacade.java
@@ -1,6 +1,7 @@
 package hhplus.ecommerce.server.application;
 
 import hhplus.ecommerce.server.domain.item.Item;
+import hhplus.ecommerce.server.domain.item.service.ItemCommand;
 import hhplus.ecommerce.server.domain.item.service.ItemInfo;
 import hhplus.ecommerce.server.domain.item.service.ItemService;
 import lombok.RequiredArgsConstructor;
@@ -22,9 +23,11 @@ public class ItemFacade {
         return ItemInfo.ItemDetail.from(topItems, stockMap);
     }
 
-    public List<ItemInfo.ItemDetail> findItems() {
-        List<Item> items = itemService.findItems();
+    public ItemInfo.ItemPageInfo pageItems(ItemCommand.ItemSearchCond searchCond) {
+        List<Item> items = itemService.findItemsBySearchCond(searchCond);
+        long count = itemService.countItemsBySearchCond(searchCond, items.size());
         Map<Long, Integer> stockMap = itemService.getStocks(items.stream().map(Item::getId).collect(Collectors.toSet()));
-        return ItemInfo.ItemDetail.from(items, stockMap);
+        List<ItemInfo.ItemDetail> itemDetails = ItemInfo.ItemDetail.from(items, stockMap);
+        return ItemInfo.ItemPageInfo.from(itemDetails, count);
     }
 }

--- a/src/main/java/hhplus/ecommerce/server/domain/item/service/ItemCommand.java
+++ b/src/main/java/hhplus/ecommerce/server/domain/item/service/ItemCommand.java
@@ -10,8 +10,8 @@ public class ItemCommand {
             String keyword
     ) {
         public static ItemSearchCond of(Integer page, Integer size, String prop, String dir, String keyword) {
-            page = page == null ? 1 : page;
-            size = size == null ? 10 : size;
+            page = page == null || page < 1 ? 1 : page;
+            size = size == null || size < 10 ? 10 : Math.min(size, 100);
             prop = prop == null ? "id" : prop;
             dir = dir == null ? "desc" : dir;
             return new ItemSearchCond(page, size, prop, dir, keyword);

--- a/src/main/java/hhplus/ecommerce/server/domain/item/service/ItemCommand.java
+++ b/src/main/java/hhplus/ecommerce/server/domain/item/service/ItemCommand.java
@@ -1,0 +1,28 @@
+package hhplus.ecommerce.server.domain.item.service;
+
+public class ItemCommand {
+
+    public record ItemSearchCond(
+            Integer page,
+            Integer size,
+            String prop,
+            String dir,
+            String keyword
+    ) {
+        public static ItemSearchCond of(Integer page, Integer size, String prop, String dir, String keyword) {
+            page = page == null ? 1 : page;
+            size = size == null ? 10 : size;
+            prop = prop == null ? "id" : prop;
+            dir = dir == null ? "desc" : dir;
+            return new ItemSearchCond(page, size, prop, dir, keyword);
+        }
+
+        public long getLimit() {
+            return size;
+        }
+
+        public long getOffset() {
+            return (long) (page - 1) * size;
+        }
+    }
+}

--- a/src/main/java/hhplus/ecommerce/server/domain/item/service/ItemCommand.java
+++ b/src/main/java/hhplus/ecommerce/server/domain/item/service/ItemCommand.java
@@ -14,6 +14,7 @@ public class ItemCommand {
             size = size == null || size < 10 ? 10 : Math.min(size, 100);
             prop = prop == null ? "id" : prop;
             dir = dir == null ? "desc" : dir;
+            keyword = keyword == null || keyword.isBlank() ? null : keyword;
             return new ItemSearchCond(page, size, prop, dir, keyword);
         }
 

--- a/src/main/java/hhplus/ecommerce/server/domain/item/service/ItemInfo.java
+++ b/src/main/java/hhplus/ecommerce/server/domain/item/service/ItemInfo.java
@@ -19,4 +19,13 @@ public class ItemInfo {
                     .toList();
         }
     }
+
+    public record ItemPageInfo(
+            List<ItemDetail> itemDetails,
+            long totalCount
+    ) {
+        public static ItemPageInfo from(List<ItemDetail> itemDetails, long totalCount) {
+            return new ItemPageInfo(itemDetails, totalCount);
+        }
+    }
 }

--- a/src/main/java/hhplus/ecommerce/server/domain/item/service/ItemRepository.java
+++ b/src/main/java/hhplus/ecommerce/server/domain/item/service/ItemRepository.java
@@ -9,11 +9,13 @@ import java.util.Set;
 
 public interface ItemRepository {
 
-    List<Item> findTopItems(LocalDateTime startDateTime, LocalDateTime endDateTime);
-
-    List<Item> findAll();
+    Optional<Item> findById(Long itemId);
 
     List<Item> findAllById(Set<Long> itemIds);
 
-    Optional<Item> findById(Long itemId);
+    List<Item> findAllBySearchCond(ItemCommand.ItemSearchCond searchCond);
+
+    long countAllBySearchCond(ItemCommand.ItemSearchCond searchCond);
+
+    List<Item> findTopItems(LocalDateTime startDateTime, LocalDateTime endDateTime);
 }

--- a/src/main/java/hhplus/ecommerce/server/domain/item/service/ItemService.java
+++ b/src/main/java/hhplus/ecommerce/server/domain/item/service/ItemService.java
@@ -7,7 +7,6 @@ import hhplus.ecommerce.server.domain.item.exception.NoSuchItemStockException;
 import hhplus.ecommerce.server.infrastructure.lock.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -27,8 +26,17 @@ public class ItemService {
         return itemRepository.findTopItems(startDateTime, endDateTime);
     }
 
-    public List<Item> findItems() {
-        return itemRepository.findAll();
+    public List<Item> findItemsBySearchCond(ItemCommand.ItemSearchCond searchCond) {
+        return itemRepository.findAllBySearchCond(searchCond);
+    }
+
+    public long countItemsBySearchCond(ItemCommand.ItemSearchCond searchCond, int contentSize) {
+        if (searchCond.size() > contentSize) {
+            if (searchCond.getOffset() == 0 || contentSize != 0) {
+                return searchCond.getOffset() + contentSize;
+            }
+        }
+        return itemRepository.countAllBySearchCond(searchCond);
     }
 
     public List<Item> findItems(Set<Long> itemIds) {

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/lock/DistributedLockAop.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/lock/DistributedLockAop.java
@@ -18,7 +18,7 @@ import java.lang.reflect.Method;
 @Slf4j
 public class DistributedLockAop {
 
-    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+    private static final String REDISSON_LOCK_PREFIX = "lock:";
 
     private final RedissonClient redissonClient;
     private final AopForTransaction aopForTransaction;

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/repository/item/ItemJpaCommandRepository.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/repository/item/ItemJpaCommandRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public interface ItemJpaRepository extends JpaRepository<Item, Long> {
+public interface ItemJpaCommandRepository extends JpaRepository<Item, Long> {
 
     @Query("""
             select i

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/repository/item/ItemJpaQueryRepository.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/repository/item/ItemJpaQueryRepository.java
@@ -1,0 +1,103 @@
+package hhplus.ecommerce.server.infrastructure.repository.item;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import hhplus.ecommerce.server.domain.item.Item;
+import hhplus.ecommerce.server.domain.item.service.ItemCommand;
+import hhplus.ecommerce.server.domain.order.QOrder;
+import hhplus.ecommerce.server.domain.order.QOrderItem;
+import hhplus.ecommerce.server.domain.order.enumeration.OrderStatus;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static hhplus.ecommerce.server.domain.item.QItem.item;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Repository
+public class ItemJpaQueryRepository {
+
+    private final EntityManager em;
+    private final JPAQueryFactory query;
+
+    public Optional<Item> findById(Long itemId) {
+        return Optional.ofNullable(em.find(Item.class, itemId));
+    }
+
+    public List<Item> findAllById(Collection<Long> itemIds) {
+        return query
+                .selectFrom(item)
+                .where(item.id.in(itemIds))
+                .fetch();
+    }
+
+    public List<Item> findAllBySearchCond(ItemCommand.ItemSearchCond searchCond) {
+        return query
+                .selectFrom(item)
+                .where(itemNameContains(searchCond.keyword()))
+                .orderBy(specifyOrder(searchCond.prop(), searchCond.dir()))
+                .limit(searchCond.getLimit())
+                .offset(searchCond.getOffset())
+                .fetch();
+    }
+
+    public long countAllBySearchCond(ItemCommand.ItemSearchCond searchCond) {
+        Long count = query.select(item.countDistinct())
+                .from(item)
+                .where(itemNameContains(searchCond.keyword()))
+                .fetchOne();
+        return count != null ? count : 0;
+    }
+
+    public List<Item> findTopItemsOrderDateTimeBetween(
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime
+    ) {
+        QOrderItem qOrderItem = QOrderItem.orderItem;
+        QOrder qOrder = QOrder.order;
+        return query
+                .select(item)
+                .from(item)
+                .leftJoin(qOrderItem).on(item.id.eq(qOrderItem.item.id))
+                .leftJoin(qOrder).on(qOrderItem.order.id.eq(qOrder.id))
+                .where(
+                        qOrder.status.eq(OrderStatus.ORDERED),
+                        qOrder.orderDateTime.between(startDateTime, endDateTime)
+                )
+                .groupBy(item)
+                .orderBy(qOrderItem.quantity.multiply(qOrderItem.price).sum().desc())
+                .limit(5)
+                .fetch();
+    }
+
+    private BooleanExpression itemNameContains(String keyword) {
+        return StringUtils.hasText(keyword) ? item.name.contains(keyword) : null;
+    }
+
+    /**
+     * @param prop 정렬 속성은 ID, name 2가지를 사용
+     * @param dir 정렬 방향은 ASC, DESC 두 가지만 사용
+     * @return OrderSpecifier
+     */
+    private OrderSpecifier<?> specifyOrder(String prop, String dir) {
+        Order order = Objects.equals(dir, "asc") ? Order.ASC : Order.DESC;
+        prop = prop.toLowerCase();
+
+        return switch (prop) {
+            case "id" -> new OrderSpecifier<>(order, item.id);
+            case "name" -> new OrderSpecifier<>(order, item.name);
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/repository/item/ItemJpaQueryRepository.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/repository/item/ItemJpaQueryRepository.java
@@ -94,10 +94,9 @@ public class ItemJpaQueryRepository {
         Order order = Objects.equals(dir, "asc") ? Order.ASC : Order.DESC;
         prop = prop.toLowerCase();
 
-        return switch (prop) {
-            case "id" -> new OrderSpecifier<>(order, item.id);
-            case "name" -> new OrderSpecifier<>(order, item.name);
-            default -> null;
-        };
+        if (prop.equals("price")) {
+            return new OrderSpecifier<>(order, item.price);
+        }
+        return new OrderSpecifier<>(order, item.id);
     }
 }

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/repository/item/ItemRepositoryImpl.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/repository/item/ItemRepositoryImpl.java
@@ -1,6 +1,7 @@
 package hhplus.ecommerce.server.infrastructure.repository.item;
 
 import hhplus.ecommerce.server.domain.item.Item;
+import hhplus.ecommerce.server.domain.item.service.ItemCommand;
 import hhplus.ecommerce.server.domain.item.service.ItemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -16,25 +17,30 @@ import java.util.Set;
 @Repository
 public class ItemRepositoryImpl implements ItemRepository {
 
-    private final ItemJpaRepository itemJpaRepository;
+    private final ItemJpaQueryRepository itemJpaCommandRepository;
 
     @Override
-    public List<Item> findTopItems(LocalDateTime startDateTime, LocalDateTime endDateTime) {
-        return itemJpaRepository.findTopItemsOrderDateTimeBetween(startDateTime, endDateTime);
-    }
-
-    @Override
-    public List<Item> findAll() {
-        return itemJpaRepository.findAll();
+    public Optional<Item> findById(Long itemId) {
+        return itemJpaCommandRepository.findById(itemId);
     }
 
     @Override
     public List<Item> findAllById(Set<Long> itemIds) {
-        return itemJpaRepository.findAllById(itemIds);
+        return itemJpaCommandRepository.findAllById(itemIds);
     }
 
     @Override
-    public Optional<Item> findById(Long itemId) {
-        return itemJpaRepository.findById(itemId);
+    public List<Item> findAllBySearchCond(ItemCommand.ItemSearchCond searchCond) {
+        return itemJpaCommandRepository.findAllBySearchCond(searchCond);
+    }
+
+    @Override
+    public long countAllBySearchCond(ItemCommand.ItemSearchCond searchCond) {
+        return itemJpaCommandRepository.countAllBySearchCond(searchCond);
+    }
+
+    @Override
+    public List<Item> findTopItems(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        return itemJpaCommandRepository.findTopItemsOrderDateTimeBetween(startDateTime, endDateTime);
     }
 }

--- a/src/main/java/hhplus/ecommerce/server/interfaces/controller/item/ItemController.java
+++ b/src/main/java/hhplus/ecommerce/server/interfaces/controller/item/ItemController.java
@@ -1,13 +1,18 @@
 package hhplus.ecommerce.server.interfaces.controller.item;
 
 import hhplus.ecommerce.server.application.ItemFacade;
+import hhplus.ecommerce.server.domain.item.service.ItemCommand;
+import hhplus.ecommerce.server.domain.item.service.ItemInfo;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -43,18 +48,34 @@ public class ItemController {
     @Operation(
             summary = "전체 상품 조회",
             description = "전체 상품 목록을 조회합니다.",
+            parameters = {
+                    @Parameter(in = ParameterIn.QUERY, schema = @Schema(name = "page", description = "페이지 번호", defaultValue = "1")),
+                    @Parameter(in = ParameterIn.QUERY, schema = @Schema(name = "size", description = "페이지 크기", defaultValue = "10")),
+                    @Parameter(in = ParameterIn.QUERY, schema = @Schema(name = "prop", description = "정렬 기준", defaultValue = "id")),
+                    @Parameter(in = ParameterIn.QUERY, schema = @Schema(name = "dir", description = "정렬 방향", defaultValue = "desc")),
+                    @Parameter(in = ParameterIn.QUERY, schema = @Schema(name = "keyword", description = "검색어"))
+            },
             responses = {
                     @ApiResponse(
                             responseCode = "200",
                             description = "전체 상품 목록",
                             content = @Content(
-                                    schema = @Schema(implementation = ItemDto.ItemResponseList.class)
+                                    schema = @Schema(implementation = ItemDto.ItemPageInfo.class)
                             )
                     )
             }
     )
     @GetMapping("")
-    public ItemDto.ItemResponseList findItems() {
-        return ItemDto.ItemResponseList.from(itemFacade.findItems());
+    public ItemDto.ItemPageInfo findItems(
+            @Parameter(hidden = true) @ModelAttribute ItemDto.ItemSearchCond searchCond
+    ) {
+        ItemInfo.ItemPageInfo itemPageInfo = itemFacade.pageItems(ItemCommand.ItemSearchCond.of(
+                searchCond.page(),
+                searchCond.size(),
+                searchCond.prop(),
+                searchCond.dir(),
+                searchCond.keyword()
+        ));
+        return ItemDto.ItemPageInfo.from(itemPageInfo.itemDetails(), itemPageInfo.totalCount());
     }
 }

--- a/src/main/java/hhplus/ecommerce/server/interfaces/controller/item/ItemDto.java
+++ b/src/main/java/hhplus/ecommerce/server/interfaces/controller/item/ItemDto.java
@@ -44,4 +44,34 @@ public class ItemDto {
             );
         }
     }
+
+    public record ItemSearchCond(
+            @Schema(name = "page", description = "페이지 번호", example = "1")
+            Integer page,
+            @Schema(name = "size", description = "페이지 크기", example = "10")
+            Integer size,
+            @Schema(name = "prop", description = "정렬 기준", example = "name")
+            String prop,
+            @Schema(name = "dir", description = "정렬 방향", example = "asc")
+            String dir,
+            @Schema(name = "keyword", description = "검색어", example = "사과")
+            String keyword
+    ) {
+    }
+
+    public record ItemPageInfo(
+            @Schema(name = "items", description = "상품 목록", example = "[{\"id\":101, \"name\":\"사과\", \"price\":1000, \"amount\":3}]")
+            List<ItemResponse> items,
+            @Schema(name = "totalCount", description = "전체 상품 수", example = "100")
+            long totalCount
+    ) {
+        public static ItemPageInfo from(List<ItemInfo.ItemDetail> itemDetails, long totalCount) {
+            return new ItemPageInfo(
+                    itemDetails.stream()
+                            .map(ItemResponse::from)
+                            .toList(),
+                    totalCount
+            );
+        }
+    }
 }

--- a/src/main/resources/application-stage.properties
+++ b/src/main/resources/application-stage.properties
@@ -35,3 +35,6 @@ springdoc.default-produces-media-type=application/json;charset=UTF-8
 logging.level.p6spy=off
 decorator.datasource.p6spy.enable-logging=false
 decorator.datasource.p6spy.log-file=
+
+# cache logging
+logging.level.org.springframework.cache=trace

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -19,6 +19,11 @@ spring.data.redis.port=6379
 # controller advice
 spring.mvc.log-resolved-exception=false
 
+# swagger
+springdoc.api-docs.path=/swagger-ui
+springdoc.default-consumes-media-type=application/json;charset=UTF-8
+springdoc.default-produces-media-type=application/json;charset=UTF-8
+
 # spring logging
 logging.file.path=./logs
 logging.file.name=./logs/application.log
@@ -28,12 +33,10 @@ logging.logback.rollingpolicy.max-history=8
 logging.logback.rollingpolicy.total-size-cap=50MB
 logging.logback.rollingpolicy.clean-history-on-start=false
 
-# swagger
-springdoc.api-docs.path=/swagger-ui
-springdoc.default-consumes-media-type=application/json;charset=UTF-8
-springdoc.default-produces-media-type=application/json;charset=UTF-8
-
 # p6spy logging
 logging.level.p6spy=trace
 decorator.datasource.p6spy.enable-logging=true
 decorator.datasource.p6spy.log-file=
+
+# cache logging
+logging.level.org.springframework.cache=trace

--- a/src/test/java/hhplus/ecommerce/server/integration/application/CartFacadeTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/application/CartFacadeTest.java
@@ -7,7 +7,7 @@ import hhplus.ecommerce.server.domain.item.Item;
 import hhplus.ecommerce.server.domain.item.ItemStock;
 import hhplus.ecommerce.server.domain.user.User;
 import hhplus.ecommerce.server.infrastructure.repository.cart.CartJpaRepository;
-import hhplus.ecommerce.server.infrastructure.repository.item.ItemJpaRepository;
+import hhplus.ecommerce.server.infrastructure.repository.item.ItemJpaCommandRepository;
 import hhplus.ecommerce.server.infrastructure.repository.item.ItemStockJpaRepository;
 import hhplus.ecommerce.server.infrastructure.repository.user.UserJpaRepository;
 import hhplus.ecommerce.server.integration.TestContainerEnvironment;
@@ -28,7 +28,7 @@ public class CartFacadeTest extends TestContainerEnvironment {
     UserJpaRepository userJpaRepository;
 
     @Autowired
-    ItemJpaRepository itemJpaRepository;
+    ItemJpaCommandRepository itemJpaCommandRepository;
 
     @Autowired
     ItemStockJpaRepository itemStockJpaRepository;
@@ -105,7 +105,7 @@ public class CartFacadeTest extends TestContainerEnvironment {
     }
 
     private Item createItem(String name, int price) {
-        return itemJpaRepository.save(Item.builder()
+        return itemJpaCommandRepository.save(Item.builder()
                 .name(name)
                 .price(price)
                 .build());

--- a/src/test/java/hhplus/ecommerce/server/integration/application/OrderFacadeConcurrencyTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/application/OrderFacadeConcurrencyTest.java
@@ -5,18 +5,16 @@ import hhplus.ecommerce.server.domain.item.Item;
 import hhplus.ecommerce.server.domain.item.ItemStock;
 import hhplus.ecommerce.server.domain.item.exception.OutOfItemStockException;
 import hhplus.ecommerce.server.domain.order.service.OrderCommand;
-import hhplus.ecommerce.server.domain.order.service.OrderService;
 import hhplus.ecommerce.server.domain.point.Point;
 import hhplus.ecommerce.server.domain.user.User;
 import hhplus.ecommerce.server.infrastructure.data.OrderDataPlatform;
-import hhplus.ecommerce.server.infrastructure.repository.item.ItemJpaRepository;
+import hhplus.ecommerce.server.infrastructure.repository.item.ItemJpaCommandRepository;
 import hhplus.ecommerce.server.infrastructure.repository.item.ItemStockJpaRepository;
 import hhplus.ecommerce.server.infrastructure.repository.order.OrderItemJpaRepository;
 import hhplus.ecommerce.server.infrastructure.repository.order.OrderJpaRepository;
 import hhplus.ecommerce.server.infrastructure.repository.point.PointJpaRepository;
 import hhplus.ecommerce.server.infrastructure.repository.user.UserJpaRepository;
 import hhplus.ecommerce.server.integration.TestContainerEnvironment;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,7 +42,7 @@ public class OrderFacadeConcurrencyTest extends TestContainerEnvironment {
     PointJpaRepository pointJpaRepository;
 
     @Autowired
-    ItemJpaRepository itemJpaRepository;
+    ItemJpaCommandRepository itemJpaCommandRepository;
 
     @Autowired
     ItemStockJpaRepository itemStockJpaRepository;
@@ -206,7 +204,7 @@ public class OrderFacadeConcurrencyTest extends TestContainerEnvironment {
     }
 
     private Item createItem(String name, int price) {
-        return itemJpaRepository.save(Item.builder()
+        return itemJpaCommandRepository.save(Item.builder()
                 .name(name)
                 .price(price)
                 .build());

--- a/src/test/java/hhplus/ecommerce/server/integration/application/OrderFacadeTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/application/OrderFacadeTest.java
@@ -13,7 +13,7 @@ import hhplus.ecommerce.server.domain.point.Point;
 import hhplus.ecommerce.server.domain.point.exception.OutOfPointException;
 import hhplus.ecommerce.server.domain.user.User;
 import hhplus.ecommerce.server.infrastructure.data.OrderDataPlatform;
-import hhplus.ecommerce.server.infrastructure.repository.item.ItemJpaRepository;
+import hhplus.ecommerce.server.infrastructure.repository.item.ItemJpaCommandRepository;
 import hhplus.ecommerce.server.infrastructure.repository.item.ItemStockJpaRepository;
 import hhplus.ecommerce.server.infrastructure.repository.order.OrderItemJpaRepository;
 import hhplus.ecommerce.server.infrastructure.repository.order.OrderJpaRepository;
@@ -22,7 +22,6 @@ import hhplus.ecommerce.server.infrastructure.repository.user.UserJpaRepository;
 import hhplus.ecommerce.server.integration.TestContainerEnvironment;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -44,7 +43,7 @@ public class OrderFacadeTest extends TestContainerEnvironment {
     PointJpaRepository pointJpaRepository;
 
     @Autowired
-    ItemJpaRepository itemJpaRepository;
+    ItemJpaCommandRepository itemJpaCommandRepository;
 
     @Autowired
     ItemStockJpaRepository itemStockJpaRepository;
@@ -284,7 +283,7 @@ public class OrderFacadeTest extends TestContainerEnvironment {
     }
 
     private Item createItem(String name, int price) {
-        return itemJpaRepository.save(Item.builder()
+        return itemJpaCommandRepository.save(Item.builder()
                 .name(name)
                 .price(price)
                 .build());

--- a/src/test/java/hhplus/ecommerce/server/integration/domain/cart/CartServiceTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/domain/cart/CartServiceTest.java
@@ -6,7 +6,7 @@ import hhplus.ecommerce.server.domain.cart.service.CartService;
 import hhplus.ecommerce.server.domain.item.Item;
 import hhplus.ecommerce.server.domain.user.User;
 import hhplus.ecommerce.server.infrastructure.repository.cart.CartJpaRepository;
-import hhplus.ecommerce.server.infrastructure.repository.item.ItemJpaRepository;
+import hhplus.ecommerce.server.infrastructure.repository.item.ItemJpaCommandRepository;
 import hhplus.ecommerce.server.infrastructure.repository.user.UserJpaRepository;
 import hhplus.ecommerce.server.integration.TestContainerEnvironment;
 import org.junit.jupiter.api.DisplayName;
@@ -27,7 +27,7 @@ public class CartServiceTest extends TestContainerEnvironment {
     UserJpaRepository userJpaRepository;
 
     @Autowired
-    ItemJpaRepository itemJpaRepository;
+    ItemJpaCommandRepository itemJpaCommandRepository;
 
     @Autowired
     CartJpaRepository cartJpaRepository;
@@ -162,7 +162,7 @@ public class CartServiceTest extends TestContainerEnvironment {
                 .name(name)
                 .price(price)
                 .build();
-        return itemJpaRepository.save(item);
+        return itemJpaCommandRepository.save(item);
     }
 
     private Cart createCart(int quantity, User user, Item item) {

--- a/src/test/java/hhplus/ecommerce/server/integration/domain/order/OrderServiceTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/domain/order/OrderServiceTest.java
@@ -9,7 +9,7 @@ import hhplus.ecommerce.server.domain.order.exception.NoSuchOrderException;
 import hhplus.ecommerce.server.domain.order.service.OrderCommand;
 import hhplus.ecommerce.server.domain.order.service.OrderService;
 import hhplus.ecommerce.server.domain.user.User;
-import hhplus.ecommerce.server.infrastructure.repository.item.ItemJpaRepository;
+import hhplus.ecommerce.server.infrastructure.repository.item.ItemJpaCommandRepository;
 import hhplus.ecommerce.server.infrastructure.repository.item.ItemStockJpaRepository;
 import hhplus.ecommerce.server.infrastructure.repository.order.OrderItemJpaRepository;
 import hhplus.ecommerce.server.infrastructure.repository.order.OrderJpaRepository;
@@ -18,7 +18,6 @@ import hhplus.ecommerce.server.integration.TestContainerEnvironment;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -41,7 +40,7 @@ public class OrderServiceTest extends TestContainerEnvironment {
     UserJpaRepository userJpaRepository;
 
     @Autowired
-    ItemJpaRepository itemJpaRepository;
+    ItemJpaCommandRepository itemJpaCommandRepository;
 
     @Autowired
     ItemStockJpaRepository itemStockJpaRepository;
@@ -196,7 +195,7 @@ public class OrderServiceTest extends TestContainerEnvironment {
     }
 
     private Item createItem(String name, int price) {
-        Item item = itemJpaRepository.save(Item.builder()
+        Item item = itemJpaCommandRepository.save(Item.builder()
                 .name(name)
                 .price(price)
                 .build());

--- a/src/test/java/hhplus/ecommerce/server/integration/domain/point/PointServiceTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/domain/point/PointServiceTest.java
@@ -6,7 +6,7 @@ import hhplus.ecommerce.server.domain.point.exception.NoSuchPointException;
 import hhplus.ecommerce.server.domain.point.exception.OutOfPointException;
 import hhplus.ecommerce.server.domain.point.service.PointService;
 import hhplus.ecommerce.server.domain.user.User;
-import hhplus.ecommerce.server.infrastructure.repository.item.ItemJpaRepository;
+import hhplus.ecommerce.server.infrastructure.repository.item.ItemJpaCommandRepository;
 import hhplus.ecommerce.server.infrastructure.repository.point.PointJpaRepository;
 import hhplus.ecommerce.server.infrastructure.repository.user.UserJpaRepository;
 import hhplus.ecommerce.server.integration.TestContainerEnvironment;
@@ -32,7 +32,7 @@ public class PointServiceTest extends TestContainerEnvironment {
     PointJpaRepository pointJpaRepository;
 
     @Autowired
-    ItemJpaRepository itemJpaRepository;
+    ItemJpaCommandRepository itemJpaCommandRepository;
 
     @DisplayName("포인트를 조회할 수 있다.")
     @Test
@@ -175,6 +175,6 @@ public class PointServiceTest extends TestContainerEnvironment {
                 .name(name)
                 .price(price)
                 .build();
-        return itemJpaRepository.save(buildItem);
+        return itemJpaCommandRepository.save(buildItem);
     }
 }

--- a/src/test/java/hhplus/ecommerce/server/integration/interfaces/controller/item/ItemControllerTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/interfaces/controller/item/ItemControllerTest.java
@@ -2,6 +2,7 @@ package hhplus.ecommerce.server.integration.interfaces.controller.item;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hhplus.ecommerce.server.application.ItemFacade;
+import hhplus.ecommerce.server.domain.item.service.ItemCommand;
 import hhplus.ecommerce.server.domain.item.service.ItemInfo;
 import hhplus.ecommerce.server.interfaces.controller.item.ItemController;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +16,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -67,33 +69,41 @@ public class ItemControllerTest {
     void findItemsTest() throws Exception {
         // given
         List<ItemInfo.ItemDetail> allItems = List.of(
-                new ItemInfo.ItemDetail(101L, "사과", 1000, 10),
-                new ItemInfo.ItemDetail(102L, "바나나", 2000, 5),
-                new ItemInfo.ItemDetail(103L, "포도", 3000, 15)
+                new ItemInfo.ItemDetail(101L, "(과일)사과", 1000, 10),
+                new ItemInfo.ItemDetail(102L, "(과일)바나나", 2000, 5),
+                new ItemInfo.ItemDetail(103L, "(과일)포도", 3000, 15)
         );
+        long totalCount = 3;
+        ItemInfo.ItemPageInfo itemPageInfo = ItemInfo.ItemPageInfo.from(allItems, totalCount);
 
-        when(itemFacade.findItems()).thenReturn(allItems);
+        when(itemFacade.pageItems(any(ItemCommand.ItemSearchCond.class))).thenReturn(itemPageInfo);
 
         // when
         ResultActions resultActions = mockMvc.perform(
                 get("/api/items")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .param("page", "1")
+                        .param("size", "10")
+                        .param("prop", "id")
+                        .param("dir", "desc")
+                        .param("keyword", "과일")
         );
 
         // then
         resultActions
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.items[0].id").value(101L))
-                .andExpect(jsonPath("$.items[0].name").value("사과"))
+                .andExpect(jsonPath("$.items[0].name").value("(과일)사과"))
                 .andExpect(jsonPath("$.items[0].price").value(1000))
                 .andExpect(jsonPath("$.items[0].amount").value(10))
                 .andExpect(jsonPath("$.items[1].id").value(102L))
-                .andExpect(jsonPath("$.items[1].name").value("바나나"))
+                .andExpect(jsonPath("$.items[1].name").value("(과일)바나나"))
                 .andExpect(jsonPath("$.items[1].price").value(2000))
                 .andExpect(jsonPath("$.items[1].amount").value(5))
                 .andExpect(jsonPath("$.items[2].id").value(103L))
-                .andExpect(jsonPath("$.items[2].name").value("포도"))
+                .andExpect(jsonPath("$.items[2].name").value("(과일)포도"))
                 .andExpect(jsonPath("$.items[2].price").value(3000))
-                .andExpect(jsonPath("$.items[2].amount").value(15));
+                .andExpect(jsonPath("$.items[2].amount").value(15))
+                .andExpect(jsonPath("$.totalCount").value(3));
     }
 }

--- a/src/test/java/hhplus/ecommerce/server/unit/domain/item/ItemCommandTest.java
+++ b/src/test/java/hhplus/ecommerce/server/unit/domain/item/ItemCommandTest.java
@@ -1,0 +1,70 @@
+package hhplus.ecommerce.server.unit.domain.item;
+
+import hhplus.ecommerce.server.domain.item.service.ItemCommand;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class ItemCommandTest {
+
+    @DisplayName("검색조건에서 값을 입력하지 않으면, page, size, prop, dir 의 기본값이 설정된다.")
+    @Test
+    void itemSearchCondDefaultValues() {
+        // given
+        // when
+        ItemCommand.ItemSearchCond searchCond = ItemCommand.ItemSearchCond.of(null, null, null, null, null);
+
+        // then
+        assertThat(searchCond.page()).isEqualTo(1);
+        assertThat(searchCond.size()).isEqualTo(10);
+        assertThat(searchCond.prop()).isEqualTo("id");
+        assertThat(searchCond.dir()).isEqualTo("desc");
+        assertThat(searchCond.keyword()).isNull();
+    }
+
+    @DisplayName("검색조건에서 page 는 최소 1 로 설정된다.")
+    @Test
+    void itemSearchCondPageMinValue() {
+        // given
+        // when
+        ItemCommand.ItemSearchCond searchCond = ItemCommand.ItemSearchCond.of(0, null, null, null, null);
+
+        // then
+        assertThat(searchCond.page()).isEqualTo(1);
+    }
+
+    @DisplayName("검색조건에서 size 는 최소 10으로 설정된다.")
+    @Test
+    void itemSearchCondSizeMinMaxValue() {
+        // given
+        // when
+        ItemCommand.ItemSearchCond searchCond = ItemCommand.ItemSearchCond.of(null, 9, null, null, null);
+
+        // then
+        assertThat(searchCond.size()).isEqualTo(10);
+    }
+
+    @DisplayName("검색조건에서 size 는 최대 100으로 설정된다.")
+    @Test
+    void itemSearchCondSizeMaxValue() {
+        // given
+        // when
+        ItemCommand.ItemSearchCond searchCond = ItemCommand.ItemSearchCond.of(null, 101, null, null, null);
+
+        // then
+        assertThat(searchCond.size()).isEqualTo(100);
+    }
+
+    @DisplayName("검색어 keyword 가 빈 문자열인 경우 null 로 설정된다.")
+    @Test
+    void itemSearchCondKeywordEmptyString() {
+        // given
+        // when
+        ItemCommand.ItemSearchCond searchCond = ItemCommand.ItemSearchCond.of(null, null, null, null, "   ");
+
+        // then
+        assertThat(searchCond.keyword()).isNull();
+    }
+}


### PR DESCRIPTION
### 변경사항
- 캐시 적용 전에, 좀 더 현실적인 상황에 가깝게 구현하기 위해 다음과 같은 파라미터를 전달 받아 최소한의 페이지네이션을 구현했습니다.
  - page : 페이지 번호
  - size : 게시물 조회 수
  - prop : 정렬 속성(id 또는 price)
  - dir : 정렬 방향(asc 또는 desc)
  - keyword : 상품 이름 검색어

### 참고사항
STEP13 PR 은 [여기](https://github.com/psam1017/hhplus-ecommerce/pull/23)에서 참고해주세요.