### PR TITLE
STEP14+ : 상품 캐시에 대한 Cache Warming 및 이벤트 기반 Cache Eviction 기능 추가

### DIFF
--- a/src/main/java/hhplus/ecommerce/server/domain/item/Item.java
+++ b/src/main/java/hhplus/ecommerce/server/domain/item/Item.java
@@ -5,9 +5,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("status = 'ACTIVE'")
 @Table(name = "items")
 @Entity
 public class Item {
@@ -20,10 +22,14 @@ public class Item {
 
     private int price;
 
+    @Enumerated(EnumType.STRING)
+    private ItemStatus status;
+
     @Builder
     protected Item(Long id, String name, int price) {
         this.id = id;
         this.name = name;
         this.price = price;
+        this.status = ItemStatus.ACTIVE;
     }
 }

--- a/src/main/java/hhplus/ecommerce/server/domain/item/ItemStatus.java
+++ b/src/main/java/hhplus/ecommerce/server/domain/item/ItemStatus.java
@@ -1,0 +1,8 @@
+package hhplus.ecommerce.server.domain.item;
+
+public enum ItemStatus {
+
+    ACTIVE,
+    HIDDEN,
+    ;
+}

--- a/src/main/java/hhplus/ecommerce/server/domain/item/service/ItemRepository.java
+++ b/src/main/java/hhplus/ecommerce/server/domain/item/service/ItemRepository.java
@@ -1,6 +1,7 @@
 package hhplus.ecommerce.server.domain.item.service;
 
 import hhplus.ecommerce.server.domain.item.Item;
+import hhplus.ecommerce.server.domain.item.ItemStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,4 +19,6 @@ public interface ItemRepository {
     long countAllBySearchCond(ItemCommand.ItemSearchCond searchCond);
 
     List<Item> findTopItems(LocalDateTime startDateTime, LocalDateTime endDateTime);
+
+    void modifyItemStatus(Long id, ItemStatus status);
 }

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/cache/CacheName.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/cache/CacheName.java
@@ -2,7 +2,9 @@ package hhplus.ecommerce.server.infrastructure.cache;
 
 public final class CacheName {
 
+    public static final String REDISSON_LOCK_PREFIX = "lock:";
     public static final String ITEMS_PAGE = "cache:items:page";
     public static final String ITEMS_TOP = "cache:items:top";
-    public static final String ITEM_WARM = "cache:item:warm";
+    public static final String ITEM_PAGE_WARM = "cache:item:warm:page";
+    public static final String ITEM_TOP_WARM = "cache:item:warm:top";
 }

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/cache/ItemCacheWarmer.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/cache/ItemCacheWarmer.java
@@ -42,7 +42,7 @@ public class ItemCacheWarmer {
                 List<String> dirs = List.of("asc", "desc");
                 for (String prop : props) {
                     for (String dir : dirs) {
-                        wareUpItemPageCache(cacheLastPage, prop, dir);
+                        warmUpItemPageCache(cacheLastPage, prop, dir);
                     }
                     em.clear();
                 }
@@ -86,7 +86,7 @@ public class ItemCacheWarmer {
                     if (items != null) {
                         for (Item item : items) {
                             if (Objects.equals(item.getId(), hiddenItemId)) {
-                                wareUpItemPageCache(cacheLastPage, prop, dir);
+                                warmUpItemPageCache(cacheLastPage, prop, dir);
                                 found.set(true);
                                 break;
                             }
@@ -113,7 +113,7 @@ public class ItemCacheWarmer {
     }
 
     @SuppressWarnings({"unchecked"})
-    private void wareUpItemPageCache(int cacheLastPage, String prop, String dir) {
+    private void warmUpItemPageCache(int cacheLastPage, String prop, String dir) {
         int size = 10;
         int initialPage = 1;
         int initialOffset = 0;

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/cache/ItemCacheWarmer.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/cache/ItemCacheWarmer.java
@@ -1,0 +1,156 @@
+package hhplus.ecommerce.server.infrastructure.cache;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hhplus.ecommerce.server.domain.item.Item;
+import hhplus.ecommerce.server.domain.item.service.ItemCommand;
+import hhplus.ecommerce.server.domain.item.service.ItemRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SessionCallback;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ItemCacheWarmer {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ItemRepository itemRepository;
+    private final EntityManager em;
+    private final ObjectMapper om;
+
+    public void warmUpItemsPageCaches(int cacheLastPage) {
+        Boolean acquired = redisTemplate.opsForValue().setIfAbsent(CacheName.ITEM_PAGE_WARM, "locked", Duration.ofMinutes(1));
+
+        if (acquired != null && acquired) {
+            log.trace("Warming up item caches");
+            try {
+                List<String> props = List.of("id", "price");
+                List<String> dirs = List.of("asc", "desc");
+                for (String prop : props) {
+                    for (String dir : dirs) {
+                        wareUpItemPageCache(cacheLastPage, prop, dir);
+                    }
+                    em.clear();
+                }
+                warmUpItemCountCache();
+            } finally {
+                redisTemplate.delete(CacheName.ITEM_PAGE_WARM);
+            }
+        }
+    }
+
+    public void warmUpTopItemCaches() {
+        Boolean acquired = redisTemplate.opsForValue().setIfAbsent(CacheName.ITEM_TOP_WARM, "locked", Duration.ofMinutes(1));
+        LocalDateTime endDateTime = LocalDateTime.now();
+        LocalDateTime startDateTime = endDateTime.minusDays(3);
+        String cacheKey = "%s::%s".formatted(CacheName.ITEMS_TOP, LocalDate.now().toString());
+
+        if (acquired != null && acquired) {
+            log.trace("Warming up top item caches");
+            try {
+                List<Item> topItems = itemRepository.findTopItems(startDateTime, endDateTime);
+                redisTemplate.opsForValue().set(cacheKey, topItems, Duration.ofHours(24));
+            } finally {
+                redisTemplate.delete(CacheName.ITEM_TOP_WARM);
+            }
+        }
+    }
+
+    public void refreshItemPageCaches(int cacheLastPage, Long hiddenItemId) {
+        List<String> props = List.of("id", "price");
+        List<String> dirs = List.of("asc", "desc");
+        AtomicBoolean found = new AtomicBoolean(false);
+        for (String prop : props) {
+            for (String dir : dirs) {
+                int size = 10;
+
+                for (int page = 1; page <= cacheLastPage; page++) {
+                    String cacheKey = "%s::page:%d:size:%d:prop:%s:dir:%s".formatted(CacheName.ITEMS_PAGE, page, size, prop, dir);
+                    Object cache = redisTemplate.opsForValue().get(cacheKey);
+                    List<Item> items = readItems(cache);
+
+                    if (items != null) {
+                        for (Item item : items) {
+                            if (Objects.equals(item.getId(), hiddenItemId)) {
+                                wareUpItemPageCache(cacheLastPage, prop, dir);
+                                found.set(true);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (found.get()) {
+            warmUpItemCountCache();
+        }
+    }
+
+    public void refershTopItemCaches(Long hiddenItemId) {
+        String cacheKey = "%s::%s".formatted(CacheName.ITEMS_TOP, LocalDate.now().toString());
+        Object cache = redisTemplate.opsForValue().get(cacheKey);
+        List<Item> topItems = readItems(cache);
+        if (topItems != null) {
+            topItems.stream().
+                    filter(i -> Objects.equals(i.getId(), hiddenItemId))
+                    .findAny()
+                    .ifPresent(item -> warmUpTopItemCaches());
+        }
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private void wareUpItemPageCache(int cacheLastPage, String prop, String dir) {
+        int size = 10;
+        int initialPage = 1;
+        int initialOffset = 0;
+
+        ItemCommand.ItemSearchCond searchCond = new ItemCommand.ItemSearchCond(initialPage, cacheLastPage * size, prop, dir, null);
+        List<Item> items = itemRepository.findAllBySearchCond(searchCond);
+        int itemSize = items.size();
+
+        redisTemplate.execute(new SessionCallback<Void>() {
+            public Void execute(@NotNull RedisOperations operations) throws DataAccessException {
+                operations.multi();
+                int page = initialPage;
+                int offset = initialOffset;
+
+                for (int i = 0; i < cacheLastPage; i++) {
+                    if (offset >= itemSize) {
+                        break;
+                    }
+                    int end = Math.min(offset + size, itemSize);
+                    List<Item> itemsPage = items.subList(offset, end);
+                    String cacheKey = "%s::page:%d:size:%d:prop:%s:dir:%s".formatted(CacheName.ITEMS_PAGE, page, size, prop, dir);
+                    operations.opsForValue().set(cacheKey, itemsPage, Duration.ofMinutes(10));
+                    offset += size;
+                    page++;
+                }
+                operations.exec();
+                return null;
+            }
+        });
+    }
+
+    private void warmUpItemCountCache() {
+        long count = itemRepository.countAllBySearchCond(ItemCommand.ItemSearchCond.of(null, null, null, null, null));
+        redisTemplate.opsForValue().set("%s::count".formatted(CacheName.ITEMS_PAGE), count, Duration.ofMinutes(10));
+    }
+
+    private List<Item> readItems(Object obj) {
+        return obj == null ? null : om.convertValue(obj, new TypeReference<>() {});
+    }
+}

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/event/ItemHiddenEvent.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/event/ItemHiddenEvent.java
@@ -1,0 +1,17 @@
+package hhplus.ecommerce.server.infrastructure.event;
+
+import org.springframework.context.ApplicationEvent;
+
+public class ItemHiddenEvent extends ApplicationEvent {
+
+    private final Long itemId;
+
+    public ItemHiddenEvent(Object source, Long itemId) {
+        super(source);
+        this.itemId = itemId;
+    }
+
+    public Long getItemId() {
+        return itemId;
+    }
+}

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/event/ItemHiddenEventHandler.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/event/ItemHiddenEventHandler.java
@@ -1,0 +1,21 @@
+package hhplus.ecommerce.server.infrastructure.event;
+
+import hhplus.ecommerce.server.infrastructure.cache.ItemCacheWarmer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class ItemHiddenEventHandler {
+
+    private final ItemCacheWarmer itemCacheWarmer;
+
+    @Async
+    @EventListener(ItemHiddenEvent.class)
+    public void handle(ItemHiddenEvent event) {
+        itemCacheWarmer.refreshItemPageCaches(100, event.getItemId());
+        itemCacheWarmer.refershTopItemCaches(event.getItemId());
+    }
+}

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/lock/DistributedLockAop.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/lock/DistributedLockAop.java
@@ -1,5 +1,6 @@
 package hhplus.ecommerce.server.infrastructure.lock;
 
+import hhplus.ecommerce.server.infrastructure.cache.CacheName;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -18,8 +19,6 @@ import java.lang.reflect.Method;
 @Slf4j
 public class DistributedLockAop {
 
-    private static final String REDISSON_LOCK_PREFIX = "lock:";
-
     private final RedissonClient redissonClient;
     private final AopForTransaction aopForTransaction;
 
@@ -29,7 +28,7 @@ public class DistributedLockAop {
         Method method = signature.getMethod();
         DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
 
-        String key = REDISSON_LOCK_PREFIX + CustomSpringELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
+        String key = CacheName.REDISSON_LOCK_PREFIX + CustomSpringELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
         RLock rLock = redissonClient.getLock(key);
 
         try {

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/repository/item/ItemJpaCommandRepository.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/repository/item/ItemJpaCommandRepository.java
@@ -1,30 +1,22 @@
 package hhplus.ecommerce.server.infrastructure.repository.item;
 
 import hhplus.ecommerce.server.domain.item.Item;
+import hhplus.ecommerce.server.domain.item.ItemStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 public interface ItemJpaCommandRepository extends JpaRepository<Item, Long> {
 
+    @Modifying(flushAutomatically = true)
     @Query("""
-            select i
-            from Item i
-            left join OrderItem oi
-            on i.id = oi.item.id
-            left join Order o
-            on oi.order.id = o.id
-            where o.status = 'ORDERED'
-              and o.orderDateTime between :startDateTime and :endDateTime
-            group by i
-            order by sum(oi.quantity * oi.price) desc
-            limit 5
+            update Item i
+            set i.status = :status
+            where i.id = :id
             """)
-    List<Item> findTopItemsOrderDateTimeBetween(
-            @Param("startDateTime") LocalDateTime startDateTime,
-            @Param("endDateTime") LocalDateTime endDateTime
+    void modifyItemStatus(
+            @Param("id") Long id,
+            @Param("status") ItemStatus status
     );
 }

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/repository/item/ItemRepositoryImpl.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/repository/item/ItemRepositoryImpl.java
@@ -1,6 +1,7 @@
 package hhplus.ecommerce.server.infrastructure.repository.item;
 
 import hhplus.ecommerce.server.domain.item.Item;
+import hhplus.ecommerce.server.domain.item.ItemStatus;
 import hhplus.ecommerce.server.domain.item.service.ItemCommand;
 import hhplus.ecommerce.server.domain.item.service.ItemRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,30 +18,36 @@ import java.util.Set;
 @Repository
 public class ItemRepositoryImpl implements ItemRepository {
 
-    private final ItemJpaQueryRepository itemJpaCommandRepository;
+    private final ItemJpaCommandRepository itemJpaCommandRepository;
+    private final ItemJpaQueryRepository itemJpaQueryRepository;
 
     @Override
     public Optional<Item> findById(Long itemId) {
-        return itemJpaCommandRepository.findById(itemId);
+        return itemJpaQueryRepository.findById(itemId);
     }
 
     @Override
     public List<Item> findAllById(Set<Long> itemIds) {
-        return itemJpaCommandRepository.findAllById(itemIds);
+        return itemJpaQueryRepository.findAllById(itemIds);
     }
 
     @Override
     public List<Item> findAllBySearchCond(ItemCommand.ItemSearchCond searchCond) {
-        return itemJpaCommandRepository.findAllBySearchCond(searchCond);
+        return itemJpaQueryRepository.findAllBySearchCond(searchCond);
     }
 
     @Override
     public long countAllBySearchCond(ItemCommand.ItemSearchCond searchCond) {
-        return itemJpaCommandRepository.countAllBySearchCond(searchCond);
+        return itemJpaQueryRepository.countAllBySearchCond(searchCond);
     }
 
     @Override
     public List<Item> findTopItems(LocalDateTime startDateTime, LocalDateTime endDateTime) {
-        return itemJpaCommandRepository.findTopItemsOrderDateTimeBetween(startDateTime, endDateTime);
+        return itemJpaQueryRepository.findTopItemsOrderDateTimeBetween(startDateTime, endDateTime);
+    }
+
+    @Override
+    public void modifyItemStatus(Long id, ItemStatus status) {
+        itemJpaCommandRepository.modifyItemStatus(id, status);
     }
 }

--- a/src/main/java/hhplus/ecommerce/server/infrastructure/scheduler/ItemCacheScheduler.java
+++ b/src/main/java/hhplus/ecommerce/server/infrastructure/scheduler/ItemCacheScheduler.java
@@ -1,0 +1,23 @@
+package hhplus.ecommerce.server.infrastructure.scheduler;
+
+import hhplus.ecommerce.server.infrastructure.cache.ItemCacheWarmer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class ItemCacheScheduler {
+
+    private final ItemCacheWarmer itemCacheWarmer;
+
+    @Scheduled(cron = "0 0/5 * * * *")
+    public void warmUp() {
+        itemCacheWarmer.warmUpItemsPageCaches(100);
+    }
+
+    @Scheduled(cron = "1 0 0 * * *")
+    public void warmUpTopItems() {
+        itemCacheWarmer.warmUpTopItemCaches();
+    }
+}

--- a/src/test/java/hhplus/ecommerce/server/integration/domain/item/ItemServiceCacheTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/domain/item/ItemServiceCacheTest.java
@@ -73,7 +73,7 @@ public class ItemServiceCacheTest extends TestContainerEnvironment {
 
         // then
         Object dataAfterCache = redisTemplate.opsForValue().get(cacheKey);
-        List<Item> cachedItems = readItems(dataAfterCache);
+        List<Item> cachedItems = convertItems(dataAfterCache);
         Item cachedItem = cachedItems.get(0);
 
         assertThat(dataBeforeCache).isNull();
@@ -125,7 +125,7 @@ public class ItemServiceCacheTest extends TestContainerEnvironment {
 
         // then
         Object dataAfterCache = redisTemplate.opsForValue().get(cacheKey);
-        List<Item> cachedItems = readItems(dataAfterCache);
+        List<Item> cachedItems = convertItems(dataAfterCache);
         Item cachedItem1 = cachedItems.get(0);
         Item cachedItem2 = cachedItems.get(1);
 
@@ -359,11 +359,7 @@ public class ItemServiceCacheTest extends TestContainerEnvironment {
         orderItemJpaRepository.save(orderItem);
     }
 
-    private List<Item> readItems(Object obj) {
-        try {
-            return om.convertValue(obj, new TypeReference<>() {});
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    private List<Item> convertItems(Object obj) {
+        return om.convertValue(obj, new TypeReference<>() {});
     }
 }

--- a/src/test/java/hhplus/ecommerce/server/integration/infrastructure/cache/ItemCacheWarmerConcurrencyTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/infrastructure/cache/ItemCacheWarmerConcurrencyTest.java
@@ -1,0 +1,71 @@
+package hhplus.ecommerce.server.integration.infrastructure.cache;
+
+import hhplus.ecommerce.server.domain.item.Item;
+import hhplus.ecommerce.server.domain.item.service.ItemCommand;
+import hhplus.ecommerce.server.domain.item.service.ItemRepository;
+import hhplus.ecommerce.server.infrastructure.cache.ItemCacheWarmer;
+import hhplus.ecommerce.server.infrastructure.repository.item.ItemJpaCommandRepository;
+import hhplus.ecommerce.server.integration.TestContainerEnvironment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.mockito.Mockito.*;
+
+public class ItemCacheWarmerConcurrencyTest extends TestContainerEnvironment {
+
+    @Autowired
+    ItemCacheWarmer itemCacheWarmer;
+
+    @SpyBean
+    ItemRepository itemRepository;
+
+    @Autowired
+    ItemJpaCommandRepository itemJpaCommandRepository;
+
+    @DisplayName("한 번에 여러 번의 캐시 워밍을 요청해도 한 번만 실행되어야 한다.")
+    @Test
+    void warmUpItemsPageCachesOnlyOnce() throws InterruptedException {
+        // given
+        for (int i = 0; i < 11; i++) {
+            createItem();
+        }
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(2);
+
+        for (int i = 0; i < 2; i++) {
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+                    itemCacheWarmer.warmUpItemsPageCaches(1);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+
+        // when
+        startLatch.countDown();
+        endLatch.await();
+
+        // then
+        verify(itemRepository, times(4)).findAllBySearchCond(any(ItemCommand.ItemSearchCond.class));
+        verify(itemRepository, times(1)).countAllBySearchCond(any(ItemCommand.ItemSearchCond.class));
+    }
+
+    private void createItem() {
+        itemJpaCommandRepository.save(Item.builder()
+                .name("item")
+                .price(1000)
+                .build());
+    }
+}

--- a/src/test/java/hhplus/ecommerce/server/integration/infrastructure/cache/ItemCacheWarmerTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/infrastructure/cache/ItemCacheWarmerTest.java
@@ -1,0 +1,337 @@
+package hhplus.ecommerce.server.integration.infrastructure.cache;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hhplus.ecommerce.server.domain.item.Item;
+import hhplus.ecommerce.server.domain.item.ItemStatus;
+import hhplus.ecommerce.server.domain.item.ItemStock;
+import hhplus.ecommerce.server.domain.item.service.ItemCommand;
+import hhplus.ecommerce.server.domain.item.service.ItemRepository;
+import hhplus.ecommerce.server.domain.item.service.ItemService;
+import hhplus.ecommerce.server.domain.order.Order;
+import hhplus.ecommerce.server.domain.order.OrderItem;
+import hhplus.ecommerce.server.domain.order.enumeration.OrderStatus;
+import hhplus.ecommerce.server.infrastructure.cache.CacheName;
+import hhplus.ecommerce.server.infrastructure.cache.ItemCacheWarmer;
+import hhplus.ecommerce.server.infrastructure.repository.item.ItemJpaCommandRepository;
+import hhplus.ecommerce.server.infrastructure.repository.item.ItemStockJpaRepository;
+import hhplus.ecommerce.server.infrastructure.repository.order.OrderItemJpaRepository;
+import hhplus.ecommerce.server.infrastructure.repository.order.OrderJpaRepository;
+import hhplus.ecommerce.server.integration.TestContainerEnvironment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+public class ItemCacheWarmerTest extends TestContainerEnvironment {
+
+    @Autowired
+    ItemCacheWarmer itemCacheWarmer;
+
+    @Autowired
+    ItemService itemService;
+
+    @Autowired
+    RedisTemplate<String, Object> redisTemplate;
+
+    @SpyBean
+    ItemRepository itemRepository;
+
+    @Autowired
+    ItemJpaCommandRepository itemJpaCommandRepository;
+
+    @Autowired
+    ItemStockJpaRepository itemStockJpaRepository;
+
+    @Autowired
+    OrderJpaRepository orderJpaRepository;
+
+    @Autowired
+    OrderItemJpaRepository orderItemJpaRepository;
+
+    @Autowired
+    ObjectMapper om;
+
+    private static Stream<Arguments> provideWarmUpItemsPageCachesData() {
+        return Stream.of(
+                Arguments.of(90, 9),
+                Arguments.of(91, 10),
+                Arguments.of(99, 10),
+                Arguments.of(100, 10),
+                Arguments.of(101, 10)
+        );
+    }
+
+    @MethodSource("provideWarmUpItemsPageCachesData")
+    @DisplayName("상품 목록을 최대 페이지 수 이내에서 정렬속성과 방향 별로 캐싱할 수 있다.")
+    @ParameterizedTest
+    void warmUpItemsPageCaches(int itemSize, int expectedPageCount) {
+        // given
+        int cacheLastPage = 10;
+        int pageSize = 10;
+        List<Item> items = new ArrayList<>();
+        for (int i = 0; i < itemSize; i++) {
+            items.add(buildItem("item" + i, i));
+        }
+        itemJpaCommandRepository.saveAll(items);
+
+        // when
+        itemCacheWarmer.warmUpItemsPageCaches(cacheLastPage);
+
+        // then
+        verify(itemRepository, times(4)).findAllBySearchCond(any(ItemCommand.ItemSearchCond.class));
+        verify(itemRepository, times(1)).countAllBySearchCond(any(ItemCommand.ItemSearchCond.class));
+
+        List<String> props = List.of("id", "price");
+        List<String> dirs = List.of("asc", "desc");
+        Set<String> cacheKeys = redisTemplate.keys("*");
+        assertThat(cacheKeys).isNotNull();
+        assertThat(cacheKeys.size()).isEqualTo(props.size() * dirs.size() * expectedPageCount + 1);
+
+        for (String prop : props) {
+            for (String dir : dirs) {
+                for (int page = 1; page <= expectedPageCount; page++) {
+                    String cacheKey = "%s::page:%d:size:%d:prop:%s:dir:%s".formatted(CacheName.ITEMS_PAGE, page, pageSize, prop, dir);
+                    Object dataAfterCache = redisTemplate.opsForValue().get(cacheKey);
+                    List<Item> itemsAfterCache = convertItems(dataAfterCache);
+                    assertThat(itemsAfterCache).isNotEmpty();
+                }
+            }
+        }
+    }
+
+    @DisplayName("상품 목록을 미리 캐싱해두면 상품을 조회할 때 쿼리를 수행하지 않는다.")
+    @Test
+    void whenWarmUpItemsPageCaches_thenNoQuery() {
+        // given
+        createItem("Test Item1", 1000);
+        itemCacheWarmer.warmUpItemsPageCaches(1);
+        ItemCommand.ItemSearchCond searchCond = new ItemCommand.ItemSearchCond(1, 10, "id", "asc", null);
+
+        // 캐시 워밍을 위한 쿼리가 발생함
+        verify(itemRepository, times(4)).findAllBySearchCond(any(ItemCommand.ItemSearchCond.class));
+        verify(itemRepository, times(1)).countAllBySearchCond(any(ItemCommand.ItemSearchCond.class));
+
+        // when
+        itemService.findItemsBySearchCond(searchCond);
+        itemService.countItemsBySearchCond(searchCond, 10);
+
+        // then - 추가적인 쿼리가 발생하지 않음
+        verify(itemRepository, times(4)).findAllBySearchCond(any(ItemCommand.ItemSearchCond.class));
+        verify(itemRepository, times(1)).countAllBySearchCond(any(ItemCommand.ItemSearchCond.class));
+    }
+
+    @DisplayName("상위 상품 목록을 미리 캐싱할 수 있다.")
+    @Test
+    void warmUpTopItemCaches() {
+        // given
+        Item item1 = createItem("Test Item1", 1000);
+        createItemStock(item1);
+        Order order = createOrder();
+        createOrderItem(item1, order);
+
+        String cacheKey = "%s::%s".formatted(CacheName.ITEMS_TOP, LocalDate.now().toString());
+        Object dataBeforeCache = redisTemplate.opsForValue().get(cacheKey);
+
+        // when
+        itemCacheWarmer.warmUpTopItemCaches();
+
+        // then
+        Object dataAfterCache = redisTemplate.opsForValue().get(cacheKey);
+        assertThat(dataBeforeCache).isNull();
+        assertThat(dataAfterCache).isNotNull();
+        List<Item> itemsAfterCache = convertItems(dataAfterCache);
+        assertThat(itemsAfterCache).isNotEmpty();
+
+        verify(itemRepository, times(1)).findTopItems(any(LocalDateTime.class), any(LocalDateTime.class));
+    }
+
+    @DisplayName("상위 상품 목록을 미리 캐싱해두면 상품을 조회할 때 쿼리를 수행하지 않는다.")
+    @Test
+    void whenWarmUpTopItemCaches_thenNoQuery() {
+        // given
+        Item item1 = createItem("Test Item1", 1000);
+        createItemStock(item1);
+        Order order = createOrder();
+        createOrderItem(item1, order);
+        itemCacheWarmer.warmUpTopItemCaches();
+
+        // 캐시 워밍을 위한 쿼리가 발생함
+        verify(itemRepository, times(1)).findTopItems(any(LocalDateTime.class), any(LocalDateTime.class));
+
+        // when
+        itemService.findTopItems();
+
+        // then - 추가적인 쿼리가 발생하지 않음
+        verify(itemRepository, times(1)).findTopItems(any(LocalDateTime.class), any(LocalDateTime.class));
+    }
+
+    @DisplayName("상위 상품 목록에서 숨겨야 할 상품이 있다면, 캐시를 갱신한다.")
+    @Test
+    void whenHiddenItemExists_thenRefreshTopItemCaches() {
+        // given
+        Order order = createOrder();
+        Item item1 = createItem("Test Item1", 1000);
+        Item item2 = createItem("Test Item2", 2000);
+        createItemStock(item1);
+        createItemStock(item2);
+        createOrderItem(item1, order);
+        createOrderItem(item2, order);
+
+        itemCacheWarmer.warmUpTopItemCaches();
+        String cacheKey = "%s::%s".formatted(CacheName.ITEMS_TOP, LocalDate.now().toString());
+        Object cacheBeforeRefresh = redisTemplate.opsForValue().get(cacheKey);
+        List<Item> topItemsBeforeRefresh = convertItems(cacheBeforeRefresh);
+
+        itemRepository.modifyItemStatus(item2.getId(), ItemStatus.HIDDEN);
+
+        // when
+        itemCacheWarmer.refershTopItemCaches(item2.getId());
+
+        // then
+        Object cacheAfterRefresh = redisTemplate.opsForValue().get(cacheKey);
+        List<Item> topItemsAfterRefresh = convertItems(cacheAfterRefresh);
+
+        assertThat(topItemsBeforeRefresh).hasSize(2)
+                .extracting(Item::getId)
+                .containsExactly(
+                        item2.getId(),
+                        item1.getId()
+                );
+        assertThat(topItemsAfterRefresh).hasSize(1)
+                .extracting(Item::getId)
+                .containsExactly(item1.getId());
+    }
+
+    @DisplayName("상위 상품 목록에서 숨겨야 할 상품이 포함되지 않는다면 캐시를 갱신하지 않는다.")
+    @Test
+    void whenHiddenItemNotExists_thenDoNotRefreshTopItemCaches() {
+        // given
+        Order order = createOrder();
+        Item item1 = createItem("Test Item1", 1000);
+        createItemStock(item1);
+        createOrderItem(item1, order);
+
+        itemCacheWarmer.warmUpTopItemCaches();
+
+        // 캐시 워밍을 위한 쿼리가 발생함
+        verify(itemRepository, times(1)).findTopItems(any(LocalDateTime.class), any(LocalDateTime.class));
+
+        // when
+        itemCacheWarmer.refershTopItemCaches(item1.getId() + 1);
+
+        // then - 추가적인 쿼리가 발생하지 않음
+        verify(itemRepository, times(1)).findTopItems(any(LocalDateTime.class), any(LocalDateTime.class));
+    }
+
+    @DisplayName("상품 목록 캐시에서 숨겨야 할 상품이 있다면, 캐시를 갱신한다.")
+    @Test
+    void whenHiddenItemExists_thenRefreshItemsPageCaches() {
+        // given
+        Item item1 = createItem("Test Item1", 1000);
+        Item item2 = createItem("Test Item2", 2000);
+        createItemStock(item1);
+        createItemStock(item2);
+
+        itemCacheWarmer.warmUpItemsPageCaches(1);
+        itemRepository.modifyItemStatus(item2.getId(), ItemStatus.HIDDEN);
+
+        // when
+        itemCacheWarmer.refreshItemPageCaches(1, item2.getId());
+
+        // then
+        verify(itemRepository, times(8)).findAllBySearchCond(any(ItemCommand.ItemSearchCond.class));
+        verify(itemRepository, times(2)).countAllBySearchCond(any(ItemCommand.ItemSearchCond.class));
+
+        List<String> props = List.of("id", "price");
+        List<String> dirs = List.of("asc", "desc");
+        for (String prop : props) {
+            for (String dir : dirs) {
+                String cacheKey = "%s::page:%d:size:%d:prop:%s:dir:%s".formatted(CacheName.ITEMS_PAGE, 1, 10, prop, dir);
+                Object cacheAfterRefresh = redisTemplate.opsForValue().get(cacheKey);
+                List<Item> itemsAfterRefresh = convertItems(cacheAfterRefresh);
+                assertThat(itemsAfterRefresh).hasSize(1)
+                        .extracting(Item::getId)
+                        .containsExactly(item1.getId());
+            }
+        }
+    }
+
+    @DisplayName("상품 목록 캐시에서 숨겨야 할 상품이 포함되지 않는다면 캐시를 갱신하지 않는다.")
+    @Test
+    void whenHiddenItemNotExists_thenDoNotRefreshItemsPageCaches() {
+        // given
+        Item item1 = createItem("Test Item1", 1000);
+        createItemStock(item1);
+
+        itemCacheWarmer.warmUpItemsPageCaches(1);
+
+        // 캐시 워밍을 위한 쿼리가 발생함
+        verify(itemRepository, times(4)).findAllBySearchCond(any(ItemCommand.ItemSearchCond.class));
+
+        // when
+        itemCacheWarmer.refreshItemPageCaches(1, item1.getId() + 1);
+
+        // then - 추가적인 쿼리가 발생하지 않음
+        verify(itemRepository, times(4)).findAllBySearchCond(any(ItemCommand.ItemSearchCond.class));
+    }
+
+    private Item buildItem(String name, int price) {
+        return Item.builder()
+                .name(name)
+                .price(price)
+                .build();
+    }
+
+    private Item createItem(String name, int price) {
+        return itemJpaCommandRepository.save(Item.builder()
+                .name(name)
+                .price(price)
+                .build());
+    }
+
+    private void createItemStock(Item item) {
+        itemStockJpaRepository.save(ItemStock.builder()
+                .amount(10)
+                .item(item)
+                .build());
+    }
+
+    private Order createOrder() {
+        Order order = Order.builder()
+                .status(OrderStatus.ORDERED)
+                .orderDateTime(LocalDateTime.now().minusDays(1))
+                .build();
+        orderJpaRepository.save(order);
+        return order;
+    }
+
+    private void createOrderItem(Item item1, Order order) {
+        OrderItem orderItem = OrderItem.builder()
+                .order(order)
+                .item(item1)
+                .name(item1.getName())
+                .price(item1.getPrice())
+                .quantity(1)
+                .build();
+        orderItemJpaRepository.save(orderItem);
+    }
+
+    private List<Item> convertItems(Object obj) {
+        return om.convertValue(obj, new TypeReference<>() {});
+    }
+}

--- a/src/test/java/hhplus/ecommerce/server/integration/infrastructure/event/ItemHiddenEventHandlerTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/infrastructure/event/ItemHiddenEventHandlerTest.java
@@ -1,0 +1,49 @@
+package hhplus.ecommerce.server.integration.infrastructure.event;
+
+import hhplus.ecommerce.server.infrastructure.cache.ItemCacheWarmer;
+import hhplus.ecommerce.server.infrastructure.event.ItemHiddenEvent;
+import hhplus.ecommerce.server.infrastructure.event.ItemHiddenEventHandler;
+import hhplus.ecommerce.server.integration.TestContainerEnvironment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+@RecordApplicationEvents
+public class ItemHiddenEventHandlerTest extends TestContainerEnvironment {
+
+    @Autowired
+    ApplicationContext applicationContext;
+
+    @Autowired
+    ApplicationEvents applicationEvents; // 주입 잘 되니까 걱정 X
+
+    @SpyBean
+    ItemHiddenEventHandler itemHiddenEventHandler;
+
+    @MockBean
+    ItemCacheWarmer itemCacheWarmer;
+
+    @DisplayName("상품 숨김 이벤트 발행 시 핸들러가 동작한다.")
+    @Test
+    void handle() {
+        // given
+        ItemHiddenEvent event = new ItemHiddenEvent(this, 1L);
+
+        // when
+        applicationContext.publishEvent(event);
+
+        // then
+        List<ItemHiddenEvent> events = applicationEvents.stream(ItemHiddenEvent.class).toList();
+        assertThat(events).isNotEmpty();
+    }
+}

--- a/src/test/java/hhplus/ecommerce/server/integration/infrastructure/scheduler/ItemCacheSchedulerTest.java
+++ b/src/test/java/hhplus/ecommerce/server/integration/infrastructure/scheduler/ItemCacheSchedulerTest.java
@@ -1,0 +1,72 @@
+package hhplus.ecommerce.server.integration.infrastructure.scheduler;
+
+import hhplus.ecommerce.server.infrastructure.scheduler.ItemCacheScheduler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.lang.reflect.Method;
+import java.time.LocalTime;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Spring 의 @Scheduled 어노테이션을 테스트합니다.
+ */
+public class ItemCacheSchedulerTest {
+
+    private static Stream<Arguments> provideTimeDividedByTen() {
+        return Stream.of(
+                Arguments.of(LocalTime.of(0, 0, 0)),
+                Arguments.of(LocalTime.of(0, 5, 0)),
+                Arguments.of(LocalTime.of(0, 10, 0)),
+                Arguments.of(LocalTime.of(0, 15, 0)),
+                Arguments.of(LocalTime.of(0, 20, 0)),
+                Arguments.of(LocalTime.of(0, 25, 0)),
+                Arguments.of(LocalTime.of(0, 30, 0)),
+                Arguments.of(LocalTime.of(0, 35, 0)),
+                Arguments.of(LocalTime.of(0, 40, 0)),
+                Arguments.of(LocalTime.of(0, 45, 0)),
+                Arguments.of(LocalTime.of(0, 50, 0)),
+                Arguments.of(LocalTime.of(0, 55, 0))
+        );
+    }
+
+    @MethodSource("provideTimeDividedByTen")
+    @DisplayName("상품 페이지네이션 캐시 워밍은 5분마다 실행된다.")
+    @ParameterizedTest
+    void warmUp(LocalTime time) throws NoSuchMethodException {
+        // given
+        Method warmUp = ItemCacheScheduler.class.getDeclaredMethod("warmUp");
+        Scheduled scheduled = warmUp.getAnnotation(Scheduled.class);
+        String cron = scheduled.cron();
+        String[] cronSplit = cron.split(" ");
+        int cronMinuteDivider = Integer.parseInt(cronSplit[1].split("/")[1]);
+
+        // then
+        assertThat(cron).isEqualTo("0 0/5 * * * *");
+        assertThat(cronSplit[0]).isEqualTo(String.valueOf(time.getSecond()));
+        assertThat(time.getMinute() % cronMinuteDivider).isEqualTo(0);
+    }
+
+    @DisplayName("상품 상위 목록 캐시 워밍은 매일 0시 1초에 실행된다.")
+    @Test
+    void warmUpTopItems() throws NoSuchMethodException {
+        // given
+        Method warmUpTopItems = ItemCacheScheduler.class.getDeclaredMethod("warmUpTopItems");
+        Scheduled scheduled = warmUpTopItems.getAnnotation(Scheduled.class);
+        String cron = scheduled.cron();
+        String[] cronSplit = cron.split(" ");
+        LocalTime time = LocalTime.of(0, 0, 1);
+
+        // then
+        assertThat(cron).isEqualTo("1 0 0 * * *");
+        assertThat(cronSplit[0]).isEqualTo(String.valueOf(time.getSecond()));
+        assertThat(cronSplit[1]).isEqualTo(String.valueOf(time.getMinute()));
+        assertThat(cronSplit[2]).isEqualTo(String.valueOf(time.getHour()));
+    }
+}


### PR DESCRIPTION
### 변경사항
- 상품 캐시를 갱신하는 배치를 구현했습니다
  - 상품 목록 캐시 TTL 은 10분이고, 상품 캐시 배치는 5분마다 실행합니다.
    - 상품 목록 캐시는 한 번에 최대 1000개의 데이터를 불러온 다음 10개씩 100 페이지로 나누고 #multiSet 을 사용해서 레디스에 일괄 등록하는 등 최대한 네트워킹 비용을 줄이려고 했습니다.
  - 상위 상품 캐시 TTL 은 24시간이고, 상품 캐시 배치는 매일 0시 1초에 실행합니다.
  - 상품 캐시를 수행하는 로직에서는 분산락(pub/sub 아님!)을 적용해서 동시에 여러 인스턴스가 요청하더라도 한 번만 실행되도록 했습니다.
- 상품 숨김 로직을 가정하고 상품 캐시 Eviction 을 구현했습니다.
  - 상품 숨김 API 까지는 구현하지 않았습니다.
  - 상품 캐시에 숨기려는 상품이 포함된 경우 기존 캐시를 일괄 갱신합니다.

### 참고사항
- STEP14 PR 은 [여기](https://github.com/psam1017/hhplus-ecommerce/pull/22)에서 참고해주세요.

### 리뷰포인트
- (STEP14+)캐시 배치 시간과 캐시 TTL 간의 적합성
  - 상품 목록 조회 Warming 은 5분마다 수행하고 TTL 은 10분입니다
  - 상품 상위 목록 Warming 은 매일 0시 1초에 수행하고, TTL 은 24시간입니다.
- (STEP14+)Cache Eviction 과 분산락 사용 여부
  - Cache Warming 에서는 여러 서버 중 락을 획득한 한 서버만 작업을 수행하도록 구현했습니다.
  - 그런데 Cache Eviction 에서도 분산락이 필요할까요? 좀 고민해보다가 분산락의 이점이 별로 없다고 생각해서 적용하진 않았는데 분산락에 의해 얻을 수 있는 Effect 및 Side Effect 에 어떤 것들이 있을까요?
    - 지금은 메시지 큐를 사용해서 순차적으로 처리해보면 어떨까 하는 생각도 드네요...!

### 바로가기
- [캐시 갱신 로직 동시성 테스트](https://github.com/psam1017/hhplus-ecommerce/pull/24/files#diff-4f512253a7c0547f5f50fc87e49e7a72e9c44dc9b629c7f0a71e3128afec35cc)
- [리뷰포인트 : STEP14+ 의 캐시 갱신 로직을 수행하는 ItemCacheWarmer.java](https://github.com/psam1017/hhplus-ecommerce/pull/24/files#diff-ebaf96219b15901c01949f7cd4d1498c461e6cf455418dbd84283ace397b11a0)
- [리뷰포인트 : STEP14 + 의 캐시 스케줄러](https://github.com/psam1017/hhplus-ecommerce/pull/24/files#diff-9e3bd9343dbff14c07d7ea6fb86c8200a42f9608ae077cdce260aa2b8b966f1b)